### PR TITLE
adapted ref_hgt correction 

### DIFF
--- a/MBsandbox/flowline_TIModel.py
+++ b/MBsandbox/flowline_TIModel.py
@@ -346,7 +346,7 @@ def run_random_climate_TIModel(gdir, nyears=1000, y0=None, halfsize=15,
         # melt_f_calib_geod_prep_inversion if no suitable melt_f was found
         # let's just check if this has worked
         np.testing.assert_allclose(ref_hgt_calib_diff,
-                        mb.flowline_mb_models[-1].ref_hgt - mb.flowline_mb_models[-1].uncorrected_ref_hgt)
+                        mb.flowline_mb_models[-1].mbmod.ref_hgt - mb.flowline_mb_models[-1].mbmod.uncorrected_ref_hgt)
     else:
         # do the quality check!
         mb.flowline_mb_models[-1].historical_climate_qc_mod(gdir)
@@ -529,9 +529,10 @@ def run_constant_climate_TIModel(gdir, nyears=1000, y0=None, halfsize=15,
     if melt_f == 'from_json':
         # instead of the quality check we corrected the height already inside of
         # melt_f_calib_geod_prep_inversion if no suitable melt_f was found
-        # let's just check if this has worked
+        # let's just check if this has worked)
         np.testing.assert_allclose(ref_hgt_calib_diff,
-                        mb.flowline_mb_models[-1].ref_hgt - mb.flowline_mb_models[-1].uncorrected_ref_hgt)
+                                   mb.flowline_mb_models[-1].mbmod.ref_hgt - mb.flowline_mb_models[
+                                       -1].mbmod.uncorrected_ref_hgt)
     else:
         # do the quality check!
         mb.flowline_mb_models[-1].historical_climate_qc_mod(gdir)

--- a/MBsandbox/help_func.py
+++ b/MBsandbox/help_func.py
@@ -543,17 +543,24 @@ def calib_inv_run(gdir=np.NaN, kwargs_for_TIModel_Sfc_Type={'melt_f_change': 'li
                                                'melt_f_ratio_snow_to_ice': 0.5},
                   mb_elev_feedback='annual',
                   nyears=300, seed=0,
-                  spinup=True, interpolation_optim=False, run_type='constant',
-                  mb_model_sub_class=TIModel_Sfc_Type, pf=2, mb_type='mb_monthly',
+                  spinup=True, interpolation_optim=False,
+                  run_type='constant',
+                  mb_model_sub_class=TIModel_Sfc_Type, pf=2,
+                  mb_type='mb_monthly',
                   grad_type='cte', y0=2004, hs=10,
-                  store_monthly_step=False, unique_samples=False, climate_type='W5E5',
-                  ensemble = 'mri-esm2-0_r1i1p1f1', ssp = 'ssp126' ):
+                  store_monthly_step=False, unique_samples=False,
+                  climate_type='W5E5',
+                  ensemble = 'mri-esm2-0_r1i1p1f1', ssp = 'ssp126'):
+    # does melt_f_calib_geod_prep_inversion,
+    # then calibrate_inversion_from_consensus
+    # then init_present_time_glacier
+    # then it runs either constant, random or from climate for a given period
+    # todo: add better documentation
+
     # ye_h = 2014
     # y0 = 1979
     dataset = climate_type
     #gdirs = [gdir]
-    url = 'https://cluster.klima.uni-bremen.de/~oggm/geodetic_ref_mb/hugonnet_2021_ds_rgi60_pergla_rates_10_20_worldwide.csv'
-    path_geodetic = utils.file_downloader(url)
 
     ye = 2100
     ye_calib = 2020
@@ -569,7 +576,7 @@ def calib_inv_run(gdir=np.NaN, kwargs_for_TIModel_Sfc_Type={'melt_f_change': 'li
                                  pf=pf,  # precipitation factor
                                  mb_type=mb_type, grad_type=grad_type,
                                  climate_type=climate_type, residual=0,
-                                 path_geodetic=path_geodetic, ye=ye_calib,
+                                 ye=ye_calib,
                                  mb_model_sub_class=mb_model_sub_class,
                                  kwargs_for_TIModel_Sfc_Type=kwargs_for_TIModel_Sfc_Type_calib,
                                  spinup=spinup)

--- a/MBsandbox/mbmod_daily_oneflowline.py
+++ b/MBsandbox/mbmod_daily_oneflowline.py
@@ -1705,6 +1705,10 @@ class TIModel(TIModel_Parent):
                      add_climate=False):
         """computes daily mass balance in m of ice per second
 
+        attention this accounts as well for leap years, hence
+        doy are not 365.25 as in get_annual_mb but the amount of days the year
+        has in reality!!! (needed for hydro model of Sarah Hanus)
+
         year has to be given as float hydro year from what the month is taken,
         hence year 2000 -> y=2000, m = 1, & year = 2000.09, y=2000, m=2 ...
         which corresponds to the real year 1999 an months October or November

--- a/MBsandbox/tests/test_hydro.py
+++ b/MBsandbox/tests/test_hydro.py
@@ -16,10 +16,6 @@ from MBsandbox.flowline_TIModel import (run_from_climate_data_TIModel,
 
 
 # get the geodetic calibration data
-url = 'https://cluster.klima.uni-bremen.de/~oggm/geodetic_ref_mb/hugonnet_2021_ds_rgi60_pergla_rates_10_20_worldwide.csv'
-path = utils.file_downloader(url)
-pd_geodetic = pd.read_csv(path, index_col='rgiid')
-pd_geodetic = pd_geodetic.loc[pd_geodetic.period == '2000-01-01_2020-01-01']
 
 DOM_BORDER = 80
 
@@ -74,7 +70,7 @@ class Test_hydro:
                                          pf=pf,  # precipitation factor
                                          mb_type=mb_type, grad_type=grad_type,
                                          climate_type=climate_type, residual=0,
-                                         path_geodetic=path, ye=ye)
+                                         ye=ye)
         #make sure melt factor is within a range
         fs = '_{}_{}_{}'.format(climate_type, mb_type, grad_type)
         melt_f = gdir.read_json(filename='melt_f_geod', filesuffix=fs).get('melt_f_pf_2')
@@ -215,7 +211,7 @@ class Test_hydro:
                                          pf=pf,  # precipitation factor
                                          mb_type=mb_type, grad_type=grad_type,
                                          climate_type=climate_type, residual=0,
-                                         path_geodetic=path, ye=ye)
+                                         ye=ye)
         #make sure melt factor is within a range
         fs = '_{}_{}_{}'.format(climate_type, mb_type, grad_type)
         melt_f = gdir.read_json(filename='melt_f_geod', filesuffix=fs).get('melt_f_pf_2')
@@ -320,7 +316,7 @@ class Test_hydro:
         #assert_allclose(frac, 0, atol=0.06)  # annual can be large (prob)
 
     # @pytest.mark.slow
-    @pytest.mark.parametrize('mb_run', ['cte', 'random', 'hist', ])
+    @pytest.mark.parametrize('mb_run', ['hist', 'cte', 'random' ])
     @pytest.mark.parametrize('mb_type', ['mb_monthly', 'mb_real_daily'])
     def test_hydro_monthly_vs_annual_from_oggm_core(self, gdir,  # inversion_params,
                                                     mb_run, mb_type):
@@ -350,7 +346,7 @@ class Test_hydro:
                                          pf=pf,  # precipitation factor
                                          mb_type=mb_type, grad_type=grad_type,
                                          climate_type=climate_type, residual=0,
-                                         path_geodetic=path, ye=ye)
+                                         ye=ye)
 
         # here just calibrate a-factor to that single glacier
         workflow.execute_entity_task(tasks.compute_downstream_line, [gdir])
@@ -538,7 +534,7 @@ class Test_hydro:
                                          pf=pf,  # precipitation factor
                                          mb_type=mb_type, grad_type=grad_type,
                                          climate_type=climate_type, residual=0,
-                                         path_geodetic=path, ye=ye)
+                                         ye=ye)
 
         # here just calibrate a-factor to that single glacier
         workflow.execute_entity_task(tasks.compute_downstream_line, [gdir])

--- a/MBsandbox/tests/test_sfc_type.py
+++ b/MBsandbox/tests/test_sfc_type.py
@@ -18,13 +18,6 @@ from MBsandbox.flowline_TIModel import (run_from_climate_data_TIModel,
 from MBsandbox.wip.projections_bayescalibration import process_isimip_data
 
 
-# get the geodetic calibration data
-url = 'https://cluster.klima.uni-bremen.de/~oggm/geodetic_ref_mb/hugonnet_2021_ds_rgi60_pergla_rates_10_20_worldwide.csv'
-path = utils.file_downloader(url)
-pd_geodetic = pd.read_csv(path, index_col='rgiid')
-pd_geodetic = pd_geodetic.loc[pd_geodetic.period == '2000-01-01_2020-01-01']
-
-
 class Test_sfc_type_run:
     #@pytest.mark.parametrize(update=['annual', 'monthly'])
     @pytest.mark.parametrize("melt_f_update", ['annual', 'monthly'])
@@ -344,7 +337,7 @@ class Test_sfc_type_run:
                                          pf=pf,  # precipitation factor
                                          mb_type=mb_type, grad_type=grad_type,
                                          climate_type=climate_type, residual=0,
-                                         path_geodetic=path, ye=ye_calib,
+                                         ye=ye_calib,
                                          mb_model_sub_class=TIModel_Sfc_Type,
                                          kwargs_for_TIModel_Sfc_Type=kwargs_for_TIModel_Sfc_Type)
         # make sure melt factor is within a range

--- a/docs/hydro_compatibility/hydro_compatibility_workflow.ipynb
+++ b/docs/hydro_compatibility/hydro_compatibility_workflow.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "39ce7b90",
+   "id": "4cebbb1c",
    "metadata": {},
    "source": [
     "# Use W5E5 v2.0 and daily mass-balance (with MBsandbox)"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fbe7e070",
+   "id": "eaa5b4e2",
    "metadata": {},
    "source": [
     "**What changed compared to last version**\n",
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ccec2024",
+   "id": "ef3f7ddb",
    "metadata": {},
    "source": [
     "**What is new?**\n",
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78c31f41",
+   "id": "486dc2c8",
    "metadata": {},
    "source": [
     "---\n",
@@ -68,18 +68,18 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "edb27e41",
+   "id": "6c28c5f8",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2021-10-26 13:52:30: oggm.cfg: Reading default parameters from the OGGM `params.cfg` configuration file.\n",
-      "2021-10-26 13:52:30: oggm.cfg: Multiprocessing switched OFF according to the parameter file.\n",
-      "2021-10-26 13:52:30: oggm.cfg: Multiprocessing: using all available processors (N=8)\n",
-      "2021-10-26 13:52:30: oggm.cfg: Multiprocessing switched ON after user settings.\n",
-      "2021-10-26 13:52:30: oggm.cfg: PARAMS['hydro_month_nh'] changed from `10` to `1`.\n"
+      "2021-10-26 15:52:56: oggm.cfg: Reading default parameters from the OGGM `params.cfg` configuration file.\n",
+      "2021-10-26 15:52:56: oggm.cfg: Multiprocessing switched OFF according to the parameter file.\n",
+      "2021-10-26 15:52:56: oggm.cfg: Multiprocessing: using all available processors (N=8)\n",
+      "2021-10-26 15:52:56: oggm.cfg: Multiprocessing switched ON after user settings.\n",
+      "2021-10-26 15:52:56: oggm.cfg: PARAMS['hydro_month_nh'] changed from `10` to `1`.\n"
      ]
     }
    ],
@@ -140,14 +140,14 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "78162a0f",
+   "id": "40838688",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2021-10-26 13:52:30: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~oggm/geodetic_ref_mb/hugonnet_2021_ds_rgi60_pergla_rates_10_20_worldwide_filled.hdf\n"
+      "2021-10-26 15:52:56: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~oggm/geodetic_ref_mb/hugonnet_2021_ds_rgi60_pergla_rates_10_20_worldwide_filled.hdf\n"
      ]
     },
     {
@@ -178,16 +178,16 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "a0222f13",
+   "id": "af2426b8",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2021-10-26 13:52:31: oggm.workflow: init_glacier_directories from prepro level 2 on 1 glaciers.\n",
-      "2021-10-26 13:52:31: oggm.workflow: Execute entity tasks [gdir_from_prepro] on 1 glaciers\n",
-      "2021-10-26 13:52:32: oggm.utils: /home/lilianschuster/OGGM/download_cache/cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.4/L1-L2_files/elev_bands/RGI62/b_080/L2/RGI60-14/RGI60-14.16.tar verified successfully.\n"
+      "2021-10-26 15:52:57: oggm.workflow: init_glacier_directories from prepro level 2 on 1 glaciers.\n",
+      "2021-10-26 15:52:57: oggm.workflow: Execute entity tasks [gdir_from_prepro] on 1 glaciers\n",
+      "2021-10-26 15:52:58: oggm.utils: /home/lilianschuster/OGGM/download_cache/cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.4/L1-L2_files/elev_bands/RGI62/b_080/L2/RGI60-14/RGI60-14.16.tar verified successfully.\n"
      ]
     }
    ],
@@ -203,278 +203,293 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "63d2b2c7",
+   "id": "2fd46985",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2021-10-26 13:52:32: oggm.workflow: init_glacier_directories from prepro level 2 on 5 glaciers.\n",
-      "2021-10-26 13:52:32: oggm.workflow: Execute entity tasks [gdir_from_prepro] on 5 glaciers\n",
-      "2021-10-26 13:52:33: oggm.utils: /home/lilianschuster/OGGM/download_cache/cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.4/L1-L2_files/elev_bands/RGI62/b_040/L2/RGI60-11/RGI60-11.00.tar verified successfully.\n",
-      "2021-10-26 13:52:33: oggm.utils: /home/lilianschuster/OGGM/download_cache/cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.4/L1-L2_files/elev_bands/RGI62/b_040/L2/RGI60-14/RGI60-14.16.tar verified successfully.\n",
-      "2021-10-26 13:52:34: oggm.utils: /home/lilianschuster/OGGM/download_cache/cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.4/L1-L2_files/elev_bands/RGI62/b_040/L2/RGI60-14/RGI60-14.08.tar verified successfully.\n",
-      "2021-10-26 13:52:34: oggm.utils: /home/lilianschuster/OGGM/download_cache/cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.4/L1-L2_files/elev_bands/RGI62/b_040/L2/RGI60-14/RGI60-14.02.tar verified successfully.\n",
-      "2021-10-26 13:52:34: oggm.workflow: Execute entity tasks [compute_downstream_line] on 5 glaciers\n",
-      "2021-10-26 13:52:34: oggm.core.centerlines: (RGI60-14.08183) compute_downstream_line\n",
-      "2021-10-26 13:52:34: oggm.core.centerlines: (RGI60-14.16678) compute_downstream_line\n",
-      "2021-10-26 13:52:34: oggm.core.centerlines: (RGI60-11.00890) compute_downstream_line\n",
-      "2021-10-26 13:52:34: oggm.core.centerlines: (RGI60-11.00897) compute_downstream_line\n",
-      "2021-10-26 13:52:34: oggm.core.centerlines: (RGI60-14.02796) compute_downstream_line\n",
-      "2021-10-26 13:52:34: oggm.workflow: Execute entity tasks [compute_downstream_bedshape] on 5 glaciers\n",
-      "2021-10-26 13:52:34: oggm.core.centerlines: (RGI60-11.00890) compute_downstream_bedshape\n",
-      "2021-10-26 13:52:34: oggm.core.centerlines: (RGI60-11.00897) compute_downstream_bedshape\n",
-      "2021-10-26 13:52:34: oggm.core.centerlines: (RGI60-14.02796) compute_downstream_bedshape\n",
-      "2021-10-26 13:52:34: oggm.core.centerlines: (RGI60-14.08183) compute_downstream_bedshape\n",
-      "2021-10-26 13:52:34: oggm.core.centerlines: (RGI60-14.16678) compute_downstream_bedshape\n",
-      "2021-10-26 13:52:40: MBsandbox.mbmod_daily_oneflowline: (RGI60-14.02796) process_w5e5_data\n",
-      "2021-10-26 13:52:40: MBsandbox.mbmod_daily_oneflowline: (RGI60-11.00890) process_w5e5_data\n",
-      "2021-10-26 13:52:40: MBsandbox.mbmod_daily_oneflowline: (RGI60-14.16678) process_w5e5_data\n",
-      "2021-10-26 13:52:40: MBsandbox.mbmod_daily_oneflowline: (RGI60-14.08183) process_w5e5_data\n",
-      "2021-10-26 13:52:40: MBsandbox.mbmod_daily_oneflowline: (RGI60-11.00897) process_w5e5_data\n",
-      "2021-10-26 13:52:40: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/w5e5v2.0/flattened/daily/w5e5v2.0_tas_global_daily_flat_glaciers_1979_2019.nc\n",
-      "2021-10-26 13:52:40: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/w5e5v2.0/flattened/daily/w5e5v2.0_tas_global_daily_flat_glaciers_1979_2019.nc\n",
-      "2021-10-26 13:52:40: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/w5e5v2.0/flattened/daily/w5e5v2.0_tas_global_daily_flat_glaciers_1979_2019.nc\n",
-      "2021-10-26 13:52:40: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/w5e5v2.0/flattened/daily/w5e5v2.0_tas_global_daily_flat_glaciers_1979_2019.nc\n",
-      "2021-10-26 13:52:40: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/w5e5v2.0/flattened/daily/w5e5v2.0_tas_global_daily_flat_glaciers_1979_2019.nc\n",
-      "2021-10-26 13:52:40: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/mswepv2.8/flattened/daily/mswep_pr_global_daily_flat_glaciers_1979_2019.nc\n",
-      "2021-10-26 13:52:40: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/mswepv2.8/flattened/daily/mswep_pr_global_daily_flat_glaciers_1979_2019.nc\n",
-      "2021-10-26 13:52:40: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/mswepv2.8/flattened/daily/mswep_pr_global_daily_flat_glaciers_1979_2019.nc\n",
-      "2021-10-26 13:52:40: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/mswepv2.8/flattened/daily/mswep_pr_global_daily_flat_glaciers_1979_2019.nc\n",
-      "2021-10-26 13:52:40: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/w5e5v2.0/flattened/daily/w5e5v2.0_glacier_invariant_flat.nc\n",
-      "2021-10-26 13:52:41: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/w5e5v2.0/flattened/daily/w5e5v2.0_glacier_invariant_flat.nc\n",
-      "2021-10-26 13:52:41: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/w5e5v2.0/flattened/daily/w5e5v2.0_glacier_invariant_flat.nc\n",
-      "2021-10-26 13:52:53: oggm.utils: /home/lilianschuster/OGGM/download_cache/cluster.klima.uni-bremen.de/~oggm/climate/era5/monthly/vdr/ERA5_lapserates_monthly.nc verified successfully.\n",
-      "2021-10-26 13:52:54: MBsandbox.help_func: (RGI60-14.08183) melt_f_calib_geod_prep_inversion\n",
-      "2021-10-26 13:52:54: MBsandbox.help_func: (RGI60-11.00890) melt_f_calib_geod_prep_inversion\n",
-      "2021-10-26 13:52:54: MBsandbox.help_func: (RGI60-14.02796) melt_f_calib_geod_prep_inversion\n",
-      "2021-10-26 13:52:54: MBsandbox.help_func: (RGI60-11.00897) melt_f_calib_geod_prep_inversion\n",
-      "2021-10-26 13:52:54: MBsandbox.help_func: (RGI60-14.16678) melt_f_calib_geod_prep_inversion\n",
-      "2021-10-26 13:52:54: oggm.core.climate: (RGI60-11.00897) apparent_mb_from_any_mb\n",
-      "2021-10-26 13:52:55: oggm.core.climate: (RGI60-11.00890) apparent_mb_from_any_mb\n",
-      "2021-10-26 13:52:56: oggm.core.climate: (RGI60-14.16678) apparent_mb_from_any_mb\n",
-      "2021-10-26 13:52:56: oggm.core.climate: (RGI60-14.02796) apparent_mb_from_any_mb\n",
-      "2021-10-26 13:52:57: oggm.core.climate: (RGI60-14.08183) apparent_mb_from_any_mb\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: Found zero or negative thickness: this should not happen.\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: Found zero or negative thickness: this should not happen.\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: Found zero or negative thickness: this should not happen.\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: Found zero or negative thickness: this should not happen.\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: Found zero or negative thickness: this should not happen.\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: Found zero or negative thickness: this should not happen.\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: Found zero or negative thickness: this should not happen.\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: Found zero or negative thickness: this should not happen.\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) prepare_for_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) mass_conservation_inversion\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: Found zero or negative thickness: this should not happen.\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) filter_inversion_output\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00897) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-11.00890) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.02796) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.08183) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.inversion: (RGI60-14.16678) get_inversion_volume\n",
-      "2021-10-26 13:52:57: oggm.core.flowline: (RGI60-14.16678) init_present_time_glacier\n",
-      "2021-10-26 13:52:57: oggm.core.flowline: (RGI60-11.00890) init_present_time_glacier\n",
-      "2021-10-26 13:52:57: oggm.core.flowline: (RGI60-14.08183) init_present_time_glacier\n",
-      "2021-10-26 13:52:57: oggm.core.flowline: (RGI60-14.02796) init_present_time_glacier\n",
-      "2021-10-26 13:52:57: oggm.core.flowline: (RGI60-11.00897) init_present_time_glacier\n",
-      "2021-10-26 13:52:57: MBsandbox.flowline_TIModel: (RGI60-11.00897) run_with_hydro_daily_daily_1980_2020_mb_real_daily_cte\n",
-      "2021-10-26 13:52:57: MBsandbox.flowline_TIModel: (RGI60-11.00890) run_with_hydro_daily_daily_1980_2020_mb_real_daily_cte\n",
-      "2021-10-26 13:52:57: MBsandbox.flowline_TIModel: (RGI60-14.16678) run_with_hydro_daily_daily_1980_2020_mb_real_daily_cte\n",
-      "2021-10-26 13:52:57: MBsandbox.flowline_TIModel: (RGI60-14.08183) run_with_hydro_daily_daily_1980_2020_mb_real_daily_cte\n",
-      "2021-10-26 13:52:57: MBsandbox.flowline_TIModel: (RGI60-11.00890) run_from_climate_data_TIModel_daily_1980_2020_mb_real_daily_cte\n",
-      "2021-10-26 13:52:57: MBsandbox.flowline_TIModel: (RGI60-11.00897) run_from_climate_data_TIModel_daily_1980_2020_mb_real_daily_cte\n",
-      "2021-10-26 13:52:57: MBsandbox.flowline_TIModel: (RGI60-14.02796) run_with_hydro_daily_daily_1980_2020_mb_real_daily_cte\n",
-      "2021-10-26 13:52:57: MBsandbox.flowline_TIModel: (RGI60-14.08183) run_from_climate_data_TIModel_daily_1980_2020_mb_real_daily_cte\n",
-      "2021-10-26 13:52:57: MBsandbox.flowline_TIModel: (RGI60-14.16678) run_from_climate_data_TIModel_daily_1980_2020_mb_real_daily_cte\n",
-      "2021-10-26 13:52:57: MBsandbox.flowline_TIModel: (RGI60-14.02796) run_from_climate_data_TIModel_daily_1980_2020_mb_real_daily_cte\n",
-      "2021-10-26 13:52:57: oggm.core.flowline: (RGI60-11.00897) flowline_model_run_daily_1980_2020_mb_real_daily_cte\n",
-      "2021-10-26 13:52:57: oggm.core.flowline: (RGI60-14.02796) flowline_model_run_daily_1980_2020_mb_real_daily_cte\n",
-      "2021-10-26 13:52:57: oggm.core.flowline: (RGI60-14.08183) flowline_model_run_daily_1980_2020_mb_real_daily_cte\n",
-      "2021-10-26 13:52:57: oggm.core.flowline: (RGI60-14.16678) flowline_model_run_daily_1980_2020_mb_real_daily_cte\n",
-      "2021-10-26 13:52:58: oggm.core.flowline: (RGI60-11.00890) flowline_model_run_daily_1980_2020_mb_real_daily_cte\n",
-      "/home/lilianschuster/massbalance-sandbox/MBsandbox/mbmod_daily_oneflowline.py:1735: UserWarning: be cautiuous when using get_daily_mb and test yourself if it does what you expect\n",
-      "  warnings.warn('be cautiuous when using get_daily_mb and test yourself if it does '\n",
-      "/home/lilianschuster/massbalance-sandbox/MBsandbox/mbmod_daily_oneflowline.py:1735: UserWarning: be cautiuous when using get_daily_mb and test yourself if it does what you expect\n",
-      "  warnings.warn('be cautiuous when using get_daily_mb and test yourself if it does '\n",
-      "/home/lilianschuster/massbalance-sandbox/MBsandbox/mbmod_daily_oneflowline.py:1735: UserWarning: be cautiuous when using get_daily_mb and test yourself if it does what you expect\n",
-      "  warnings.warn('be cautiuous when using get_daily_mb and test yourself if it does '\n",
-      "/home/lilianschuster/massbalance-sandbox/MBsandbox/mbmod_daily_oneflowline.py:1735: UserWarning: be cautiuous when using get_daily_mb and test yourself if it does what you expect\n",
-      "  warnings.warn('be cautiuous when using get_daily_mb and test yourself if it does '\n",
-      "/home/lilianschuster/massbalance-sandbox/MBsandbox/mbmod_daily_oneflowline.py:1735: UserWarning: be cautiuous when using get_daily_mb and test yourself if it does what you expect\n",
-      "  warnings.warn('be cautiuous when using get_daily_mb and test yourself if it does '\n"
+      "2021-10-26 15:52:58: oggm.workflow: init_glacier_directories from prepro level 2 on 5 glaciers.\n",
+      "2021-10-26 15:52:58: oggm.workflow: Execute entity tasks [gdir_from_prepro] on 5 glaciers\n",
+      "2021-10-26 15:52:59: oggm.utils: /home/lilianschuster/OGGM/download_cache/cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.4/L1-L2_files/elev_bands/RGI62/b_040/L2/RGI60-11/RGI60-11.00.tar verified successfully.\n",
+      "2021-10-26 15:53:00: oggm.utils: /home/lilianschuster/OGGM/download_cache/cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.4/L1-L2_files/elev_bands/RGI62/b_040/L2/RGI60-14/RGI60-14.16.tar verified successfully.\n",
+      "2021-10-26 15:53:00: oggm.utils: /home/lilianschuster/OGGM/download_cache/cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.4/L1-L2_files/elev_bands/RGI62/b_040/L2/RGI60-14/RGI60-14.08.tar verified successfully.\n",
+      "2021-10-26 15:53:00: oggm.utils: /home/lilianschuster/OGGM/download_cache/cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.4/L1-L2_files/elev_bands/RGI62/b_040/L2/RGI60-14/RGI60-14.02.tar verified successfully.\n",
+      "2021-10-26 15:53:01: oggm.workflow: Execute entity tasks [compute_downstream_line] on 5 glaciers\n",
+      "2021-10-26 15:53:01: oggm.core.centerlines: (RGI60-14.02796) compute_downstream_line\n",
+      "2021-10-26 15:53:01: oggm.core.centerlines: (RGI60-14.08183) compute_downstream_line\n",
+      "2021-10-26 15:53:01: oggm.core.centerlines: (RGI60-14.16678) compute_downstream_line\n",
+      "2021-10-26 15:53:01: oggm.core.centerlines: (RGI60-11.00897) compute_downstream_line\n",
+      "2021-10-26 15:53:01: oggm.core.centerlines: (RGI60-11.00890) compute_downstream_line\n",
+      "2021-10-26 15:53:01: oggm.workflow: Execute entity tasks [compute_downstream_bedshape] on 5 glaciers\n",
+      "2021-10-26 15:53:01: oggm.core.centerlines: (RGI60-11.00897) compute_downstream_bedshape\n",
+      "2021-10-26 15:53:01: oggm.core.centerlines: (RGI60-11.00890) compute_downstream_bedshape\n",
+      "2021-10-26 15:53:01: oggm.core.centerlines: (RGI60-14.02796) compute_downstream_bedshape\n",
+      "2021-10-26 15:53:01: oggm.core.centerlines: (RGI60-14.08183) compute_downstream_bedshape\n",
+      "2021-10-26 15:53:01: oggm.core.centerlines: (RGI60-14.16678) compute_downstream_bedshape\n",
+      "2021-10-26 15:53:02: MBsandbox.mbmod_daily_oneflowline: (RGI60-14.16678) process_w5e5_data\n",
+      "2021-10-26 15:53:02: MBsandbox.mbmod_daily_oneflowline: (RGI60-11.00890) process_w5e5_data\n",
+      "2021-10-26 15:53:02: MBsandbox.mbmod_daily_oneflowline: (RGI60-14.08183) process_w5e5_data\n",
+      "2021-10-26 15:53:02: MBsandbox.mbmod_daily_oneflowline: (RGI60-14.02796) process_w5e5_data\n",
+      "2021-10-26 15:53:02: MBsandbox.mbmod_daily_oneflowline: (RGI60-11.00897) process_w5e5_data\n",
+      "2021-10-26 15:53:02: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/w5e5v2.0/flattened/daily/w5e5v2.0_tas_global_daily_flat_glaciers_1979_2019.nc\n",
+      "2021-10-26 15:53:02: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/w5e5v2.0/flattened/daily/w5e5v2.0_tas_global_daily_flat_glaciers_1979_2019.nc\n",
+      "2021-10-26 15:53:02: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/w5e5v2.0/flattened/daily/w5e5v2.0_tas_global_daily_flat_glaciers_1979_2019.nc\n",
+      "2021-10-26 15:53:02: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/w5e5v2.0/flattened/daily/w5e5v2.0_tas_global_daily_flat_glaciers_1979_2019.nc\n",
+      "2021-10-26 15:53:02: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/w5e5v2.0/flattened/daily/w5e5v2.0_tas_global_daily_flat_glaciers_1979_2019.nc\n",
+      "2021-10-26 15:53:02: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/mswepv2.8/flattened/daily/mswep_pr_global_daily_flat_glaciers_1979_2019.nc\n",
+      "2021-10-26 15:53:02: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/mswepv2.8/flattened/daily/mswep_pr_global_daily_flat_glaciers_1979_2019.nc\n",
+      "2021-10-26 15:53:02: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/mswepv2.8/flattened/daily/mswep_pr_global_daily_flat_glaciers_1979_2019.nc\n",
+      "2021-10-26 15:53:02: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/mswepv2.8/flattened/daily/mswep_pr_global_daily_flat_glaciers_1979_2019.nc\n",
+      "2021-10-26 15:53:02: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/mswepv2.8/flattened/daily/mswep_pr_global_daily_flat_glaciers_1979_2019.nc\n",
+      "2021-10-26 15:53:02: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/w5e5v2.0/flattened/daily/w5e5v2.0_glacier_invariant_flat.nc\n",
+      "2021-10-26 15:53:02: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/w5e5v2.0/flattened/daily/w5e5v2.0_glacier_invariant_flat.nc\n",
+      "2021-10-26 15:53:02: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/w5e5v2.0/flattened/daily/w5e5v2.0_glacier_invariant_flat.nc\n",
+      "2021-10-26 15:53:02: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/w5e5v2.0/flattened/daily/w5e5v2.0_glacier_invariant_flat.nc\n",
+      "2021-10-26 15:53:02: oggm.utils: No known hash for cluster.klima.uni-bremen.de/~lschuster/w5e5v2.0/flattened/daily/w5e5v2.0_glacier_invariant_flat.nc\n",
+      "2021-10-26 15:53:16: oggm.utils: /home/lilianschuster/OGGM/download_cache/cluster.klima.uni-bremen.de/~oggm/climate/era5/monthly/vdr/ERA5_lapserates_monthly.nc verified successfully.\n",
+      "2021-10-26 15:53:18: MBsandbox.help_func: (RGI60-11.00897) melt_f_calib_geod_prep_inversion\n",
+      "2021-10-26 15:53:18: MBsandbox.help_func: (RGI60-14.08183) melt_f_calib_geod_prep_inversion\n",
+      "2021-10-26 15:53:18: MBsandbox.help_func: (RGI60-14.02796) melt_f_calib_geod_prep_inversion\n",
+      "2021-10-26 15:53:18: MBsandbox.help_func: (RGI60-11.00890) melt_f_calib_geod_prep_inversion\n",
+      "2021-10-26 15:53:18: MBsandbox.help_func: (RGI60-14.16678) melt_f_calib_geod_prep_inversion\n",
+      "2021-10-26 15:53:19: oggm.core.climate: (RGI60-11.00897) apparent_mb_from_any_mb\n",
+      "2021-10-26 15:53:20: oggm.core.climate: (RGI60-11.00890) apparent_mb_from_any_mb\n",
+      "2021-10-26 15:53:22: oggm.core.climate: (RGI60-14.16678) apparent_mb_from_any_mb\n",
+      "2021-10-26 15:53:22: oggm.core.climate: (RGI60-14.02796) apparent_mb_from_any_mb\n",
+      "2021-10-26 15:53:23: oggm.core.climate: (RGI60-14.08183) apparent_mb_from_any_mb\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: Found zero or negative thickness: this should not happen.\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: Found zero or negative thickness: this should not happen.\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: Found zero or negative thickness: this should not happen.\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: Found zero or negative thickness: this should not happen.\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: Found zero or negative thickness: this should not happen.\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: Found zero or negative thickness: this should not happen.\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: Found zero or negative thickness: this should not happen.\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: Found zero or negative thickness: this should not happen.\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) get_inversion_volume\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) prepare_for_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) mass_conservation_inversion\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: Found zero or negative thickness: this should not happen.\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00890) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.16678) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.02796) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-11.00897) filter_inversion_output\n",
+      "2021-10-26 15:53:23: oggm.core.inversion: (RGI60-14.08183) filter_inversion_output\n",
+      "2021-10-26 15:53:24: oggm.core.inversion: (RGI60-11.00890) get_inversion_volume\n",
+      "2021-10-26 15:53:24: oggm.core.inversion: (RGI60-11.00897) get_inversion_volume\n",
+      "2021-10-26 15:53:24: oggm.core.inversion: (RGI60-14.16678) get_inversion_volume\n",
+      "2021-10-26 15:53:24: oggm.core.inversion: (RGI60-14.08183) get_inversion_volume\n",
+      "2021-10-26 15:53:24: oggm.core.inversion: (RGI60-14.02796) get_inversion_volume\n",
+      "2021-10-26 15:53:24: oggm.core.flowline: (RGI60-11.00890) init_present_time_glacier\n",
+      "2021-10-26 15:53:24: oggm.core.flowline: (RGI60-11.00897) init_present_time_glacier\n",
+      "2021-10-26 15:53:24: oggm.core.flowline: (RGI60-14.02796) init_present_time_glacier\n",
+      "2021-10-26 15:53:24: oggm.core.flowline: (RGI60-14.08183) init_present_time_glacier\n",
+      "2021-10-26 15:53:24: oggm.core.flowline: (RGI60-14.16678) init_present_time_glacier\n",
+      "2021-10-26 15:53:24: MBsandbox.flowline_TIModel: (RGI60-11.00890) run_from_climate_data_TIModel_W5E5_MSWEP_mb_real_daily_cte\n",
+      "2021-10-26 15:53:24: MBsandbox.flowline_TIModel: (RGI60-11.00897) run_from_climate_data_TIModel_W5E5_MSWEP_mb_real_daily_cte\n",
+      "2021-10-26 15:53:24: MBsandbox.flowline_TIModel: (RGI60-14.08183) run_from_climate_data_TIModel_W5E5_MSWEP_mb_real_daily_cte\n",
+      "2021-10-26 15:53:24: MBsandbox.flowline_TIModel: (RGI60-14.02796) run_from_climate_data_TIModel_W5E5_MSWEP_mb_real_daily_cte\n",
+      "2021-10-26 15:53:24: MBsandbox.flowline_TIModel: (RGI60-14.16678) run_from_climate_data_TIModel_W5E5_MSWEP_mb_real_daily_cte\n",
+      "2021-10-26 15:53:24: oggm.core.flowline: (RGI60-11.00890) flowline_model_run_W5E5_MSWEP_mb_real_daily_cte\n",
+      "2021-10-26 15:53:24: oggm.core.flowline: (RGI60-14.02796) flowline_model_run_W5E5_MSWEP_mb_real_daily_cte\n",
+      "2021-10-26 15:53:24: oggm.core.flowline: (RGI60-14.08183) flowline_model_run_W5E5_MSWEP_mb_real_daily_cte\n",
+      "2021-10-26 15:53:24: oggm.core.flowline: (RGI60-11.00897) flowline_model_run_W5E5_MSWEP_mb_real_daily_cte\n",
+      "2021-10-26 15:53:24: oggm.core.flowline: (RGI60-14.16678) flowline_model_run_W5E5_MSWEP_mb_real_daily_cte\n",
+      "2021-10-26 15:53:25: oggm.core.flowline: (RGI60-11.00897) run_with_hydro_random_spinup_test\n",
+      "2021-10-26 15:53:25: oggm.core.flowline: (RGI60-11.00890) run_with_hydro_random_spinup_test\n",
+      "2021-10-26 15:53:25: oggm.core.flowline: (RGI60-14.16678) run_with_hydro_random_spinup_test\n",
+      "2021-10-26 15:53:25: MBsandbox.flowline_TIModel: (RGI60-11.00890) run_random_climate_TIModel_random_spinup_test\n",
+      "2021-10-26 15:53:25: MBsandbox.flowline_TIModel: (RGI60-11.00897) run_random_climate_TIModel_random_spinup_test\n",
+      "2021-10-26 15:53:25: oggm.core.flowline: (RGI60-14.02796) run_with_hydro_random_spinup_test\n",
+      "2021-10-26 15:53:25: oggm.core.flowline: (RGI60-14.08183) run_with_hydro_random_spinup_test\n",
+      "2021-10-26 15:53:25: MBsandbox.flowline_TIModel: (RGI60-14.08183) run_random_climate_TIModel_random_spinup_test\n",
+      "2021-10-26 15:53:25: MBsandbox.flowline_TIModel: (RGI60-14.02796) run_random_climate_TIModel_random_spinup_test\n",
+      "2021-10-26 15:53:25: MBsandbox.flowline_TIModel: (RGI60-14.16678) run_random_climate_TIModel_random_spinup_test\n",
+      "2021-10-26 15:53:25: oggm.core.flowline: (RGI60-11.00897) flowline_model_run_random_spinup_test\n",
+      "2021-10-26 15:53:25: oggm.core.flowline: (RGI60-11.00890) flowline_model_run_random_spinup_test\n",
+      "2021-10-26 15:53:25: oggm.core.flowline: (RGI60-14.16678) flowline_model_run_random_spinup_test\n",
+      "2021-10-26 15:53:25: oggm.core.flowline: (RGI60-14.08183) flowline_model_run_random_spinup_test\n",
+      "2021-10-26 15:53:25: oggm.core.flowline: (RGI60-14.02796) flowline_model_run_random_spinup_test\n",
+      "2021-10-26 15:53:26: oggm.core.flowline: RuntimeError occurred during task flowline_model_run_random_spinup_test on RGI60-14.16678: Glacier exceeds domain boundaries, at year: 51.416666666666664\n",
+      "2021-10-26 15:53:26: MBsandbox.flowline_TIModel: RuntimeError occurred during task run_random_climate_TIModel_random_spinup_test on RGI60-14.16678: Glacier exceeds domain boundaries, at year: 51.416666666666664\n",
+      "2021-10-26 15:53:26: oggm.core.flowline: RuntimeError occurred during task run_with_hydro_random_spinup_test on RGI60-14.16678: Glacier exceeds domain boundaries, at year: 51.416666666666664\n",
+      "/home/lilianschuster/massbalance-sandbox/MBsandbox/mbmod_daily_oneflowline.py:1650: UserWarning: there might be a problem with SEC_IN_MONTHas February changes amount of days inbetween the years see test_monthly_glacier_massbalance()\n",
+      "  warnings.warn('there might be a problem with SEC_IN_MONTH'\n",
+      "2021-10-26 15:53:26: oggm.core.flowline: RuntimeError occurred during task flowline_model_run_random_spinup_test on RGI60-14.02796: Glacier exceeds domain boundaries, at year: 66.66666666666667\n",
+      "2021-10-26 15:53:26: MBsandbox.flowline_TIModel: RuntimeError occurred during task run_random_climate_TIModel_random_spinup_test on RGI60-14.02796: Glacier exceeds domain boundaries, at year: 66.66666666666667\n",
+      "2021-10-26 15:53:26: oggm.core.flowline: RuntimeError occurred during task run_with_hydro_random_spinup_test on RGI60-14.02796: Glacier exceeds domain boundaries, at year: 66.66666666666667\n",
+      "/home/lilianschuster/massbalance-sandbox/MBsandbox/mbmod_daily_oneflowline.py:1650: UserWarning: there might be a problem with SEC_IN_MONTHas February changes amount of days inbetween the years see test_monthly_glacier_massbalance()\n",
+      "  warnings.warn('there might be a problem with SEC_IN_MONTH'\n",
+      "/home/lilianschuster/massbalance-sandbox/MBsandbox/mbmod_daily_oneflowline.py:1650: UserWarning: there might be a problem with SEC_IN_MONTHas February changes amount of days inbetween the years see test_monthly_glacier_massbalance()\n",
+      "  warnings.warn('there might be a problem with SEC_IN_MONTH'\n"
      ]
     }
    ],
@@ -497,7 +512,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4acdd694",
+   "id": "389017cd",
    "metadata": {},
    "source": [
     "### things that can be changed before calibration\n"
@@ -506,7 +521,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "3b99d0d5",
+   "id": "36a0c9db",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -521,7 +536,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90059b5a",
+   "id": "44a3cb19",
    "metadata": {},
    "source": [
     "### melt_f calibration and inversion with glen-a calibration"
@@ -530,71 +545,71 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "c7d805c6",
+   "id": "bd464eca",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2021-10-26 13:52:40: oggm.workflow: Execute entity tasks [process_w5e5_data] on 5 glaciers\n",
-      "2021-10-26 13:52:54: oggm.workflow: Execute entity tasks [melt_f_calib_geod_prep_inversion] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Applying global task calibrate_inversion_from_consensus on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Consensus estimate optimisation with A factor: 0.1 and fs: 0\n",
-      "2021-10-26 13:52:57: oggm.workflow: Applying global task inversion_tasks on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [filter_inversion_output] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [get_inversion_volume] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Consensus estimate optimisation with A factor: 10.0 and fs: 0\n",
-      "2021-10-26 13:52:57: oggm.workflow: Applying global task inversion_tasks on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [filter_inversion_output] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [get_inversion_volume] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Consensus estimate optimisation with A factor: 7.990217184704413 and fs: 0\n",
-      "2021-10-26 13:52:57: oggm.workflow: Applying global task inversion_tasks on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [filter_inversion_output] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [get_inversion_volume] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Consensus estimate optimisation with A factor: 4.045108592352206 and fs: 0\n",
-      "2021-10-26 13:52:57: oggm.workflow: Applying global task inversion_tasks on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [filter_inversion_output] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [get_inversion_volume] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Consensus estimate optimisation with A factor: 2.383924352914521 and fs: 0\n",
-      "2021-10-26 13:52:57: oggm.workflow: Applying global task inversion_tasks on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [filter_inversion_output] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [get_inversion_volume] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Consensus estimate optimisation with A factor: 3.081936500821793 and fs: 0\n",
-      "2021-10-26 13:52:57: oggm.workflow: Applying global task inversion_tasks on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [filter_inversion_output] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [get_inversion_volume] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Consensus estimate optimisation with A factor: 2.975138279377063 and fs: 0\n",
-      "2021-10-26 13:52:57: oggm.workflow: Applying global task inversion_tasks on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [filter_inversion_output] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [get_inversion_volume] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Consensus estimate optimisation with A factor: 2.960262587979178 and fs: 0\n",
-      "2021-10-26 13:52:57: oggm.workflow: Applying global task inversion_tasks on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [filter_inversion_output] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [get_inversion_volume] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: calibrate_inversion_from_consensus converged after 7 iterations and fs=0. The resulting Glen A factor is 2.960262587979178.\n",
-      "2021-10-26 13:52:57: oggm.workflow: Applying global task inversion_tasks on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [filter_inversion_output] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [get_inversion_volume] on 5 glaciers\n",
-      "2021-10-26 13:52:57: oggm.workflow: Execute entity tasks [init_present_time_glacier] on 5 glaciers\n"
+      "2021-10-26 15:53:02: oggm.workflow: Execute entity tasks [process_w5e5_data] on 5 glaciers\n",
+      "2021-10-26 15:53:18: oggm.workflow: Execute entity tasks [melt_f_calib_geod_prep_inversion] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Applying global task calibrate_inversion_from_consensus on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Consensus estimate optimisation with A factor: 0.1 and fs: 0\n",
+      "2021-10-26 15:53:23: oggm.workflow: Applying global task inversion_tasks on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [filter_inversion_output] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [get_inversion_volume] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Consensus estimate optimisation with A factor: 10.0 and fs: 0\n",
+      "2021-10-26 15:53:23: oggm.workflow: Applying global task inversion_tasks on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [filter_inversion_output] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [get_inversion_volume] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Consensus estimate optimisation with A factor: 7.990217184704413 and fs: 0\n",
+      "2021-10-26 15:53:23: oggm.workflow: Applying global task inversion_tasks on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [filter_inversion_output] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [get_inversion_volume] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Consensus estimate optimisation with A factor: 4.045108592352206 and fs: 0\n",
+      "2021-10-26 15:53:23: oggm.workflow: Applying global task inversion_tasks on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [filter_inversion_output] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [get_inversion_volume] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Consensus estimate optimisation with A factor: 2.383924352914521 and fs: 0\n",
+      "2021-10-26 15:53:23: oggm.workflow: Applying global task inversion_tasks on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [filter_inversion_output] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [get_inversion_volume] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Consensus estimate optimisation with A factor: 3.081936500821793 and fs: 0\n",
+      "2021-10-26 15:53:23: oggm.workflow: Applying global task inversion_tasks on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [filter_inversion_output] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [get_inversion_volume] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Consensus estimate optimisation with A factor: 2.975138279377063 and fs: 0\n",
+      "2021-10-26 15:53:23: oggm.workflow: Applying global task inversion_tasks on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [filter_inversion_output] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [get_inversion_volume] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Consensus estimate optimisation with A factor: 2.960262587979178 and fs: 0\n",
+      "2021-10-26 15:53:23: oggm.workflow: Applying global task inversion_tasks on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [filter_inversion_output] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [get_inversion_volume] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: calibrate_inversion_from_consensus converged after 7 iterations and fs=0. The resulting Glen A factor is 2.960262587979178.\n",
+      "2021-10-26 15:53:23: oggm.workflow: Applying global task inversion_tasks on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 5 glaciers\n",
+      "2021-10-26 15:53:23: oggm.workflow: Execute entity tasks [filter_inversion_output] on 5 glaciers\n",
+      "2021-10-26 15:53:24: oggm.workflow: Execute entity tasks [get_inversion_volume] on 5 glaciers\n",
+      "2021-10-26 15:53:24: oggm.workflow: Execute entity tasks [init_present_time_glacier] on 5 glaciers\n"
      ]
     }
    ],
@@ -662,7 +677,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61b0ba54",
+   "id": "c7d55db4",
    "metadata": {},
    "source": [
     "#### like that we can access the calibrated melt_f (and prcp-fac)"
@@ -671,7 +686,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "c04ad19a",
+   "id": "5e6325aa",
    "metadata": {},
    "outputs": [
     {
@@ -694,7 +709,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "da39e126",
+   "id": "ece42d16",
    "metadata": {},
    "outputs": [
     {
@@ -717,7 +732,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c24d64ad",
+   "id": "3d8bc0dd",
    "metadata": {},
    "source": [
     "## check if daily_hydro works"
@@ -726,7 +741,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "840cb074",
+   "id": "7ad469c8",
    "metadata": {},
    "outputs": [
     {
@@ -762,7 +777,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "ee2a7327",
+   "id": "4f4c6273",
    "metadata": {},
    "outputs": [
     {
@@ -2065,7 +2080,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35416a28",
+   "id": "2bb5ec95",
    "metadata": {},
    "source": [
     "###  just look at volume changes starting from rgi_date"
@@ -2073,66 +2088,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "cbede79f",
+   "execution_count": 9,
+   "id": "4f419e70",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2021-10-26 13:45:55: MBsandbox.flowline_TIModel: (RGI60-11.00890) run_from_climate_data_TIModel_W5E5_MSWEP_mb_real_daily_cte\n",
-      "2021-10-26 13:45:55: oggm.core.flowline: (RGI60-11.00890) flowline_model_run_W5E5_MSWEP_mb_real_daily_cte\n"
+      "2021-10-26 15:53:24: oggm.workflow: Execute entity tasks [run_from_climate_data_TIModel] on 5 glaciers\n",
+      "2021-10-26 15:53:24: oggm.utils: Applying global task compile_run_output on 5 glaciers\n",
+      "2021-10-26 15:53:24: oggm.utils: Applying compile_run_output on 5 gdirs.\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<oggm.core.flowline.FluxBasedModel at 0x7f849c553340>"
+       "[<matplotlib.lines.Line2D at 0x7f877942e070>]"
       ]
      },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "gdir = gdirs[0]\n",
-    "y0=2004\n",
-    "ye_h = ye - 1 \n",
-    "run_from_climate_data_TIModel(gdir, bias=0, #will actually point to the residual, should always be zero! \n",
-    "                            mb_model_sub_class=TIModel,\n",
-    "                                  min_ys=y0, ye=ye_h,\n",
-    "                                  mb_type=mb_type,\n",
-    "                                  grad_type=grad_type,\n",
-    "                                  precipitation_factor=pf, \n",
-    "                                  melt_f='from_json', #melt_f_file=melt_f_file, # need to set these to find the right calibrated melt_f\n",
-    "                                  climate_input_filesuffix=climate_type,\n",
-    "                                  output_filesuffix='_{}_{}_{}'.format(climate_type, mb_type, grad_type))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "789639c8",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2021-10-26 13:45:57: oggm.workflow: Execute entity tasks [run_from_climate_data_TIModel] on 5 glaciers\n",
-      "2021-10-26 13:45:57: oggm.utils: Applying global task compile_run_output on 5 glaciers\n",
-      "2021-10-26 13:45:57: oggm.utils: Applying compile_run_output on 5 gdirs.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x7f8434709940>]"
-      ]
-     },
-     "execution_count": 11,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -2173,7 +2148,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "944904ad",
+   "id": "00c8784c",
    "metadata": {},
    "source": [
     "### similar to hydro_tutorial, but values for HEF are quite different????, \n",
@@ -2185,17 +2160,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "303d5588",
+   "execution_count": 10,
+   "id": "70a33210",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2021-07-15 12:51:14: oggm.workflow: Execute entity task run_with_hydro on 2 glaciers\n",
-      "2021-07-15 12:51:15: oggm.utils: Applying global task compile_run_output on 2 glaciers\n",
-      "2021-07-15 12:51:15: oggm.utils: Applying compile_run_output on 2 gdirs.\n"
+      "2021-10-26 15:53:25: oggm.workflow: Execute entity tasks [run_with_hydro] on 5 glaciers\n"
+     ]
+    },
+    {
+     "ename": "RuntimeError",
+     "evalue": "Glacier exceeds domain boundaries, at year: 51.416666666666664",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mRemoteTraceback\u001b[0m                           Traceback (most recent call last)",
+      "\u001b[0;31mRemoteTraceback\u001b[0m: \n\"\"\"\nTraceback (most recent call last):\n  File \"/home/lilianschuster/anaconda3/envs/pymc3_oggm/lib/python3.9/multiprocessing/pool.py\", line 125, in worker\n    result = (True, func(*args, **kwds))\n  File \"/home/lilianschuster/anaconda3/envs/pymc3_oggm/lib/python3.9/multiprocessing/pool.py\", line 48, in mapstar\n    return list(map(*args))\n  File \"/home/lilianschuster/oggm/oggm/workflow.py\", line 108, in __call__\n    res = self._call_internal(func, arg, kwargs)\n  File \"/home/lilianschuster/oggm/oggm/workflow.py\", line 102, in _call_internal\n    return call_func(gdir, **kwargs)\n  File \"/home/lilianschuster/oggm/oggm/utils/_workflow.py\", line 490, in _entity_task\n    out = task_func(gdir, **kwargs)\n  File \"/home/lilianschuster/oggm/oggm/core/flowline.py\", line 3046, in run_with_hydro\n    out = run_task(gdir, **kwargs)\n  File \"/home/lilianschuster/oggm/oggm/utils/_workflow.py\", line 490, in _entity_task\n    out = task_func(gdir, **kwargs)\n  File \"/home/lilianschuster/massbalance-sandbox/MBsandbox/flowline_TIModel.py\", line 370, in run_random_climate_TIModel\n    return flowline_model_run(gdir, output_filesuffix=output_filesuffix,\n  File \"/home/lilianschuster/oggm/oggm/utils/_workflow.py\", line 490, in _entity_task\n    out = task_func(gdir, **kwargs)\n  File \"/home/lilianschuster/oggm/oggm/core/flowline.py\", line 2667, in flowline_model_run\n    model.run_until_and_store(ye,\n  File \"/home/lilianschuster/oggm/oggm/core/flowline.py\", line 1058, in run_until_and_store\n    self.run_until(yr)\n  File \"/home/lilianschuster/oggm/oggm/core/flowline.py\", line 855, in run_until\n    raise RuntimeError('Glacier exceeds domain boundaries, '\nRuntimeError: Glacier exceeds domain boundaries, at year: 51.416666666666664\n\"\"\"",
+      "\nThe above exception was the direct cause of the following exception:\n",
+      "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-10-f304560acad1>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# ds = ds_runoff.sel(rgi_id=df[-1])\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m workflow.execute_entity_task(tasks.run_with_hydro, gdirs,\n\u001b[0m\u001b[1;32m      3\u001b[0m                              \u001b[0mrun_task\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mrun_random_climate_TIModel\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m                              \u001b[0mstore_monthly_hydro\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m                              \u001b[0mnyears\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m100\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/oggm/oggm/workflow.py\u001b[0m in \u001b[0;36mexecute_entity_task\u001b[0;34m(task, gdirs, **kwargs)\u001b[0m\n\u001b[1;32m    183\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mcfg\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mPARAMS\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'use_multiprocessing'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mng\u001b[0m \u001b[0;34m>\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    184\u001b[0m         \u001b[0mmppool\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0minit_mp_pool\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcfg\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mCONFIG_MODIFIED\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 185\u001b[0;31m         \u001b[0mout\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmppool\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmap\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mgdirs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mchunksize\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    186\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    187\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mng\u001b[0m \u001b[0;34m>\u001b[0m \u001b[0;36m3\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/envs/pymc3_oggm/lib/python3.9/multiprocessing/pool.py\u001b[0m in \u001b[0;36mmap\u001b[0;34m(self, func, iterable, chunksize)\u001b[0m\n\u001b[1;32m    362\u001b[0m         \u001b[0;32min\u001b[0m \u001b[0ma\u001b[0m \u001b[0mlist\u001b[0m \u001b[0mthat\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0mreturned\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    363\u001b[0m         '''\n\u001b[0;32m--> 364\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_map_async\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfunc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0miterable\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmapstar\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mchunksize\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    365\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    366\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mstarmap\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0miterable\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mchunksize\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/envs/pymc3_oggm/lib/python3.9/multiprocessing/pool.py\u001b[0m in \u001b[0;36mget\u001b[0;34m(self, timeout)\u001b[0m\n\u001b[1;32m    769\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_value\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    770\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 771\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_value\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    772\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    773\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_set\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mi\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mobj\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/envs/pymc3_oggm/lib/python3.9/multiprocessing/pool.py\u001b[0m in \u001b[0;36mworker\u001b[0;34m()\u001b[0m\n\u001b[1;32m    123\u001b[0m         \u001b[0mjob\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mi\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkwds\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtask\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    124\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 125\u001b[0;31m             \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwds\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    126\u001b[0m         \u001b[0;32mexcept\u001b[0m \u001b[0mException\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    127\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mwrap_exception\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mfunc\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0m_helper_reraises_exception\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/envs/pymc3_oggm/lib/python3.9/multiprocessing/pool.py\u001b[0m in \u001b[0;36mmapstar\u001b[0;34m()\u001b[0m\n\u001b[1;32m     46\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     47\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0mmapstar\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 48\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0mlist\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmap\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     49\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     50\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0mstarmapstar\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/oggm/oggm/workflow.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m()\u001b[0m\n\u001b[1;32m    106\u001b[0m         \u001b[0;32mfor\u001b[0m \u001b[0mfunc\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcall_func\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    107\u001b[0m             \u001b[0mfunc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkwargs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 108\u001b[0;31m             \u001b[0mres\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_call_internal\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfunc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0marg\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    109\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mres\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    110\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/oggm/oggm/workflow.py\u001b[0m in \u001b[0;36m_call_internal\u001b[0;34m()\u001b[0m\n\u001b[1;32m    100\u001b[0m             \u001b[0mkwargs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mupdate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mgdir_kwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    101\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 102\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mcall_func\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mgdir\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    103\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    104\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__call__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0marg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/oggm/oggm/utils/_workflow.py\u001b[0m in \u001b[0;36m_entity_task\u001b[0;34m()\u001b[0m\n\u001b[1;32m    488\u001b[0m                     \u001b[0msignal\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0malarm\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcfg\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mPARAMS\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'task_timeout'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    489\u001b[0m                 \u001b[0mex_t\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtime\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 490\u001b[0;31m                 \u001b[0mout\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtask_func\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mgdir\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    491\u001b[0m                 \u001b[0mex_t\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtime\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m-\u001b[0m \u001b[0mex_t\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    492\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0mcfg\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mPARAMS\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'task_timeout'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m>\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/oggm/oggm/core/flowline.py\u001b[0m in \u001b[0;36mrun_with_hydro\u001b[0;34m()\u001b[0m\n\u001b[1;32m   3044\u001b[0m                                  \"when asked for monthly hydro output).\")\n\u001b[1;32m   3045\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 3046\u001b[0;31m     \u001b[0mout\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mrun_task\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mgdir\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   3047\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mout\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3048\u001b[0m         raise InvalidWorkflowError('The run task ({}) did not run '\n",
+      "\u001b[0;32m~/oggm/oggm/utils/_workflow.py\u001b[0m in \u001b[0;36m_entity_task\u001b[0;34m()\u001b[0m\n\u001b[1;32m    488\u001b[0m                     \u001b[0msignal\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0malarm\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcfg\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mPARAMS\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'task_timeout'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    489\u001b[0m                 \u001b[0mex_t\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtime\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 490\u001b[0;31m                 \u001b[0mout\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtask_func\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mgdir\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    491\u001b[0m                 \u001b[0mex_t\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtime\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m-\u001b[0m \u001b[0mex_t\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    492\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0mcfg\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mPARAMS\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'task_timeout'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m>\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/massbalance-sandbox/MBsandbox/flowline_TIModel.py\u001b[0m in \u001b[0;36mrun_random_climate_TIModel\u001b[0;34m()\u001b[0m\n\u001b[1;32m    368\u001b[0m         \u001b[0mmb\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mflowline_mb_models\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmbmod\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mspinup_yrs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    369\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 370\u001b[0;31m     return flowline_model_run(gdir, output_filesuffix=output_filesuffix,\n\u001b[0m\u001b[1;32m    371\u001b[0m                               \u001b[0mmb_model\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmb\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mys\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mye\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mnyears\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    372\u001b[0m                               \u001b[0mstore_monthly_step\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mstore_monthly_step\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/oggm/oggm/utils/_workflow.py\u001b[0m in \u001b[0;36m_entity_task\u001b[0;34m()\u001b[0m\n\u001b[1;32m    488\u001b[0m                     \u001b[0msignal\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0malarm\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcfg\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mPARAMS\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'task_timeout'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    489\u001b[0m                 \u001b[0mex_t\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtime\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 490\u001b[0;31m                 \u001b[0mout\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtask_func\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mgdir\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    491\u001b[0m                 \u001b[0mex_t\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtime\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m-\u001b[0m \u001b[0mex_t\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    492\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0mcfg\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mPARAMS\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'task_timeout'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m>\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/oggm/oggm/core/flowline.py\u001b[0m in \u001b[0;36mflowline_model_run\u001b[0;34m()\u001b[0m\n\u001b[1;32m   2665\u001b[0m         \u001b[0;31m# For operational runs we ignore the warnings\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2666\u001b[0m         \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwarnings\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfilterwarnings\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'ignore'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcategory\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mRuntimeWarning\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2667\u001b[0;31m         model.run_until_and_store(ye,\n\u001b[0m\u001b[1;32m   2668\u001b[0m                                   \u001b[0mgeom_path\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mgeom_path\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2669\u001b[0m                                   \u001b[0mdiag_path\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdiag_path\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/oggm/oggm/core/flowline.py\u001b[0m in \u001b[0;36mrun_until_and_store\u001b[0;34m()\u001b[0m\n\u001b[1;32m   1056\u001b[0m         \u001b[0;32mfor\u001b[0m \u001b[0mi\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0myr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmo\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32min\u001b[0m \u001b[0menumerate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mzip\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmonthly_time\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmonths\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1057\u001b[0m             \u001b[0;31m# Model run\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1058\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrun_until\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0myr\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1059\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1060\u001b[0m             \u001b[0;31m# Glacier geometry\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/oggm/oggm/core/flowline.py\u001b[0m in \u001b[0;36mrun_until\u001b[0;34m()\u001b[0m\n\u001b[1;32m    853\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcheck_for_boundaries\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    854\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfls\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mthick\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m>\u001b[0m \u001b[0;36m10\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 855\u001b[0;31m                     raise RuntimeError('Glacier exceeds domain boundaries, '\n\u001b[0m\u001b[1;32m    856\u001b[0m                                        'at year: {}'.format(self.yr))\n\u001b[1;32m    857\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mRuntimeError\u001b[0m: Glacier exceeds domain boundaries, at year: 51.416666666666664"
      ]
     }
    ],
@@ -2231,33 +2233,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "44041f40",
+   "execution_count": null,
+   "id": "3697a337",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x7ff4f9c20f40>]"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY4AAAEoCAYAAABPQRaPAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAsgklEQVR4nO3dd3hUVf7H8fd3ZtJISOi9iUqRDkF0197F3hC7rmUt6C6W3664K7bVXdcua0Ox66pr7x27YGiCSA9VSmghJKSf3x93ohFDyKTdyczn9TzzXHLvnZnvScJ8cu899xxzziEiIlJTAb8LEBGRpkXBISIiEVFwiIhIRBQcIiISEQWHiIhERMEhIiIRUXCIiEhEYio4zOxaM3vJzJaYmTOzpfX42v3M7DkzW2pmhWa2zMyeN7NB9fUeIiJNgcXSDYBm5oCNwHRgGLDFOdejHl53EPANsAl4BFgJ7Ar8EUgF9nbOzajr+4iINAUhvwuoZ7s655YAmNkcIK2eXvdSIAUvIGZVrDSzT4APgXMABYeIxIWYOlVVERo1ZWaZZvaqma03syIzm29m15nZ9oGaHl7+tN36iq/za1OviEhTFFPBEQkzGwl8BfQC7gSuwDsddRPw/Ha7vx9ePm1mI8yss5ntCzwKrAYeapyqRUT8F1PXOCqrOFVV1TUOM0sGlgILgIOcc6WVto0F7gIOdM5NDq8z4AbgSn59+msqcIJzbvsjERGRmBWvRxyHAu2Bx4EWZtam4gG8E97nsIqdnZeua/COUC4DjscLkr7A62aW0Xili4j4K9YujtdU3/ByUjX7tK/4h5ndAowB+jjn1oRXv25mU4B3gWuAvzVEoSIi0SZeg8PCy2uAmTvY5ycAM0sArgY+rBQaADjn3jOzPGD/BqpTRCTqxGtwLAwv851zH+1k3zZAEhDcfkP42keQ+P0+ikgcitdrHO8D64C/mlmr7TeaWYqZNQ9/uRbYAOxnZrtst+sooBnwXUMWKyISTWKqV5WZnQV0D395OZCI19UWYJlz7ulK+x4OvAZsxbvWsQhoAfQBTsTrLTU5vO8Y4H4gB6/r7UpgMHABkAsMc84tb7CGiYhEkagIjvBf/ePweit1AfKAOcD1zrkvInidyez4esNnzrkDttu/P/BX4ECgLd6QIovxLnj/xzm3sdK+J+GF0RC8o4wc4CNgvHMuu6Y1iog0db4Hh5l1Bybj3R/xGN69FRnAQOB959x//atORES2Fw0XdZ/Bq2Ogc26138WIiEj1fA0OM9sP2Ae4wjm3Otz1NcE5VxDJ67Rp08b16NGjIUoUEYlZ06ZNW++caxvp8/w+4hgZXi43szeBI4GgmS0EbnLOPVOTF+nRowdZWVkNVaOISEwys2W1eZ7f3XF7h5cTgVZ4w5OfDxTjDSh43o6eaGYXmVmWmWXl5OQ0fKUiIgL4fHHczD4CDgaWAH2dc8Xh9S3D6wqBzs658upeJzMz0+mIQ0QkMmY2zTmXGenz/D7i2BZePl8RGgDOuU3AG0AHfjkqERGRKOB3cKwML9dUsa2ih1XLRqpFRERqwO/gmBpedqliW8W6dY1Ui4iI1IDfwfEa3l3iZ5rZzxMkmVlHvLvIFzrnFvlTmoiIVMXX7rjOuU1mdjXwMPCtmU3CG1/qkvByjJ/1iYjIb/l9xIFz7hHgJLzBBm8GrgPm403d+kFDvveTXy/lw7lr8XvYFRGRpsTvGwABcM69ArzSmO9ZVu54fupy5q3Jo1+ndP508O4cukd7vCk2RERkR3w/4vBLMGC8dfk+3HHKILYWlXLR09O48Kksyst19CEiUp24DQ6AUDDAycO68PGV+3PN4b356Md1PP71Ur/LEhGJanEdHBVCwQCXHrArh/Rtx7/em8e8NVv8LklEJGopOMLMjH+eNJD05BB//u9MCkvK/C5JRCQqKTgqaZOWxL9PHsS8NXnc8f58v8sREYlKCo7tHNinHWfv3Z1Hv8zmo7lr/S5HRCTqKDiqMG5kX/p1Sueql2axclNEc0qJiMQ8BUcVkhOCPHDGUMrLHZc9N4Pi0mpHdRcRiSsKjh3o3jqVf58ykFkrNnPrOz/6XY6ISNRQcFTjiP4dOfd3PXji66XMXLHZ73JERKKCgmMnrj68N23Skrjlrbka00pEBAXHTqUlhbjqsF5kLdvEu3Oqmm9KRCS+KDhqYFRmV/p0aM5t7/5IUaluDBSR+KbgqIFgwLjuqL6s2LiNJzWWlYjEOQVHDe27e1sO7N2W+z9ZRPb6fL/LERHxjYIjAjcc24+EYICzJ01hXV6h3+WIiPhCwRGB7q1TmXTucDZsLeacSd+xpbDE75JERBqdgiNCg7u24MEzh7FwbR4XPZWli+UiEncUHLWwf6+23HHKIL5dspHb3pnndzkiIo1KwVFLxw/pzPn77MITXy/l7e9X+12OiEijUXDUwV+O6MOQbi34y8vfq6eViMQNBUcdJIYCTDh9KKGgcemz0zVroIjEBQVHHXVukcLdowbz4+ot3PPRQr/LERFpcAqOenBgn3aMyuzCxC+W8MNPuX6XIyLSoBQc9WTcyL60bJbAta/Mpqxco+iKSOxScNSTFs0SGX9MP75fmcvjX2X7XY6ISINRcNSjowd25KA+7bjzgwWs2Ki5ykUkNik46pGZcfPx/QkGjD+/MJOSMs1VLiKxR8FRzzq3SOHWEwcwbdkm7v5wgd/liIjUOwVHAzh2UCdGD+/KA5MX8/mCHL/LERGpVwqOBjL+mH70ap/GlS/OZN0WDcEuIrFDwdFAUhKDTDh9KFuLSrn4mWm6q1xEYoaCowH1at+cu0cNZvryzVz10izKdX+HiMQABUcDO3JAR649sg9vf7+aOz+c73c5IiJ1FvK7gHhw0X49WbqhgP98upguLZtx2p7d/C5JRKTWFByNwMy46bh+rM7dxrhXZ5MUCnDi0C5+lyUiUis6VdVIEoIBHjpzGHv3bM3VL83ijVk/+V2SiEitKDgaUXJCkEfPySSzRyvGvjCT9+Zo5kARaXoUHI2sWWKIx88dzsAuGVz14iyWbdDMgSLStCg4fJCaFGLC6UMJBIyxL8ykVGNaiUgTouDwSecWKfzjhAFMX76ZCZ8u8rscEZEaU3D46NhBnThhSGfu/2QR05dv8rscEZEaUXD47Mbj+tEhPZnLn5vBWo1pJSJNgILDZ+nJCTx81jA2FxRzzqSp5G4r8bskEZFqKTiiQP/OGTx8ViaLc7Zy4ZNZGhBRRKKagiNK7LN7G+4aNZjvlm1k7AszcU4DIopIdFJwRJFjBnXimsN78+6cNXz84zq/yxERqZKCI8pcuG9PerZN5dZ3fqS4VPd3iEj0UXBEmYRggOtG9mXJ+nye+XaZ3+WIiPyGgiMKHdSnHfvs1oZ7P17I5oJiv8sREfkVBUcUMjP+dnRf8gpLuOejhX6XIyLyKwqOKNWnQzqnDu/G098u48uF6/0uR0TkZwqOKDZuZB92a5vGJc9MY8HaPL/LEREBFBxRrXlyApPOG05yYpDzHv+OnLwiv0sSEVFwRLvOLVJ47JxMNuQXccFTuqtcRPyn4GgCBnZpwT2nDmHWis3c/t58v8sRkTin4GgijujfgbP37s6kr7L5fEGO3+WISByLuuAws2Zmlm1mzswm+F1PNBk3si+7tUvj6pdmsTFf93eIiD+iLjiAm4A2fhcRjZITgtw7ejCbCoq59pXvNRCiiPgiqoLDzIYCfwbG+1xK1OrXKYOrD+vN+z+s5cQHv+arRbrHQ0QaV9QEh5kFgYnAe8ArPpcT1S7ctye3nTiANbmFnPHoFE575Ft+2rzN77JEJE5ETXAAY4E+wBi/C4l2gYBx2p7d+PTqAxh/zB7MXpXLpc9O12i6ItIooiI4zGwX4EbgJufc0ho+5yIzyzKzrJyc+OxllJwQ5Lzf78LtJw9k5orN3P7ePL9LEpE4EBXBATwIZAN31fQJzrlHnHOZzrnMtm3bNlxlTcDIAR05Z+/uPPplNh/8sMbvckQkxtU6OMws1cyGmNm+dSnAzM4EDgMuds6V1OW14tm4o/oyoHMGV780ixUbC/wuR0RiWMTBYWZdzOxlYBOQBXxaads+ZjbXzA6o4Wsl4R1lvAOsMbPdzGw3oHt4l4zwuhaR1hlvkkJB/nP6UBxw2XPTKSrV0CQi0jAiCg4z6whMAY4D3gK+AazSLlOAdsCpNXzJFKAtcBSwsNJjcnj7meGvL4ikznjVrXUz7jxlEN+vzOXmt+b6XY6IxKhQhPuPxwuGQ5xzk81sPLB3xUbnXImZfQH8voavlw+cUsX6tsADeF1zHwO+j7DOuHVYvw5cvP+uPPTZYoZ2a8mJQ7v4XZKIxJhIg2Mk8IZzbnI1+ywHanTdI3xN43/brzezHuF/LnbO/Wa7VO/qw3oxc8Umxr06mz06pdOnQ7rfJYlIDIn0Gkd7vFNH1SkBUmtXjtSHUDDAfacNIT05gcuenU5BcanfJYlIDIk0ODYCXXeyTy+gTn1CnXNLnXPmnNPNgLXUrnkyd586mCXr83W9Q0TqVaTB8RVwrJl1qGqjme0OHEGlnlbin9/v1oaL99+V56eu4J3Zq/0uR0RiRKTB8W8gGfjMzI4EmsHP93QcCbwJlAN31muVUmtXHtqLQV1b8NeXv2eVxrMSkXoQUXA456YAFwE98LrjXh3etCX89S7A+c65H+qxRqmDhGCA+0YPptzBlS/MpLxcQ7GLSN1EfAOgc+5xoD9wHzAVWAxMx+s+O9A592y9Vih11r11Kn8/ui9Tsjfy7JRlfpcjIk1cpN1xAXDOLcQbzVaaiFGZXXnr+9Xc9u48Dujdjq6tmvldkog0UdEyyKE0MDPjnycNxIC/avZAEamDWh1xmFkA6Ax0ARKq2sc593kd6pIG0LlFCteO7MvfXpvDc1OXc8aI7jt/kojIdiIODjO7Bu+i+M7mBQ/WqiJpUKfv2Y335qxh/Os/0Do1kSP6d/S7JBFpYiIKDjO7Abge2AA8CawCdFtyExIIGA+cOZRzJ03lsudmcO9ox9EDO/ldlog0IZEecZwPLAGGOedyG6AeaQTpyQk8df4I/vD4d1zx/AzKyh3HDe7sd1ki0kREenG8Nd4ghwqNJi4tKcQTfxjOnru04qoXZ5G1dKPfJYlIExFpcCwCWjZEIdL4miWGePisTLq0TOGSZ6ezbkuh3yWJSBMQaXA8ABy9o7GqpOnJSEng4bMyyS8q5ZJnp1NcWu53SSIS5SIdcuQh4GngKzM7x8wGmFm3qh4NU640hN4dmnP7yQOZtmwTN731g+7xEJFq1eY+jlnAucCkavZxtXxt8cnRAzsxe1UuD3+2hGaJIa49sg9mtvMnikjcibQ77gXAw3hdcCcDP6HuuDHjL4f3obC4jEc+X0JRSRnjj+lHIKDwEJFfi/So4CpgHfA751x2A9QjPgoEjBuO7UdiKMDEL7IpLnPcekJ/HXmIyK9EGhw9gEcVGrHLzBg3si+hYIAHJy9mr56tdI+HiPxKpL2qVrGDsakkdpgZVx/Wm/6d07n1nR/ZWqSzkSLyi0iD4ylgpJk1b4hiJHoEA8ZNx/Vn7ZYi7vt4od/liEgUiTQ4bsWbvOkjMztAARLbhnZryamZXZn0ZTYL1+b5XY6IRIlIg6MIOAEYDnwMbDazsioeOrcRI/7viN40Swwy/g3d3yEinkgvjn+Bd4+GxInWaUlcc3hv/v76D/zn00WMOWh3v0sSEZ9FFBzOuQMaqA6JYmeM6M705Zu544MFtElLYvSeGhhAJJ7p7m7ZqUDAuP3kgWzML2bcq7NpmZrI4f00XJlIvNKc41IjCcEAD545lIFdWnD58zOYtmyT3yWJiE8skgueZnZ9DXd1zrmba1dS5DIzM11WVlZjvV1c25RfzPEPfEVBcRlvjtmHDhnJfpckIrVkZtOcc5kRPy/C4KhuzO2KFzK84Gi0OccVHI1r/po8TnjgK3Zv35wXLtqL5ARNLy/SFNU2OCI9VXXgDh4nALcB+cALwEGRFiJNR+8Ozblr1CBmrdjM9a/PUTddkTgTaa+qz6rZ/LqZvYB3g+B/61SVRL0j+nfk8oN24/5PFrFLmzQuOWBXv0sSkUZSrxfHnXOzgdeBcfX5uhKdxh7Si6MHduRf781j0pca91IkXjREd9zlwDEN8LoSZQIB4+5TB1NSVs5Nb80lIRTgrL26+12WiDSwhuiOOwLY1gCvK1EoIRjg/tOGcnCfdvz9tTn84+25rMsr9LssEWlAkc4AuKNbhkNAV+BCYB/gxTrWJU1IYijAA2cO5bpX5/DYl9k8+c0yThnWhSsO3p326equKxJratMdt7onGLAQOMg5t6qOtdWYuuNGj6Xr83n48yW8PG0l3Vo34/XLfk9qkgYoEIlGjXUfxxNUHRzlwCa8HlWvO+eKIi2kLhQc0efrRes587EpHDOoE/ecOljTz4pEodoGR6Tdcc+N9A0kPv1utzaMPaQXd364gD13acUZI3TRXCRWaKwqaTCXHbgb+/dqy41vzGXOqly/yxGReqLgkAZT0V23TVoiY56bTkGx5vcSiQXVnqoys09q+brOOXdwLZ8rMaRVaiJ3nTqY0yZ+y63v/Mgtxw/wuyQRqaOdXeM4oJavq8GL5Gd79WzNBfvswsQvsjmkb3sO6N3O75JEpA6qPVXlnAvU8qHhUuVXrjqsN73ap/F///uezQXFfpcjInWgaxzSKJITgtw1avDPswhqRF2RpkvBIY2mf+cMrjm8N+/MXsMDkxf7XY6I1FKtgsPMRpvZR2a2wcxKzWyjmX1oZqPru0CJLRft15NjB3Xijg/m8+HctX6XIyK1EFFwmOdp4Fm8yZrSgRygOXAw8KyZPVfvVUrMMDNuP3kgAzpn8Of/zmDemi1+lyQiEYr0iOOPwBnAdOAQINk51xFIDn89DTjVzC6u1yolpiQnBHnkrExSk0Jc+FQWG/N1sVykKYk0OP4ALAX2c8594pwrA3DOlTnnPgH2D28/vz6LlNjTISOZh88axtotRVz27HRKyqqbzl5EokmkwbEH8Kpzrsr5NsLrXwP61rEuiQNDurXkthMG8M2SDdzy1ly/yxGRGop0vGuHN3R6dTQMqtTYScO68OPqLTz6ZTZ9O6Yzes8dTfkiItEi0iOOH4ETzSylqo3h9ccD+vNRauyvR/Zhv15t+fvrc5i+fJPf5YjITkQaHJOAbsDnZnawmYUAzCxoZgcCnwLdw/uJ1EgoGOD+0UPokJHMpc9MZ/3WRp3ORUQiFGlwPAw8DwwDPgC2mdlaoBD4CNgTeMk591C9VikxL6NZAg+eMYxNBcVc/twMSnWxXCRqRRQcznMGXpfcT4BcoFV4+QlwhnNONwFKrfTvnMEtx/fnmyUbuOODBX6XIyI7ENHFcTNr4Zzb7Jx7Hu/IQ6RenZLZlRkrNvPQZ4sZ0q0Fh/fr4HdJIrKdSE9VrTazF8xspJlpnCtpEOOP2YNBXTK4+sVZZK/P97scEdlOpB/+S4FTgDeBVWb2bzOr08w8ZtbLzG4ys2/NLMfM8sxsppldZ2apdXltaZqSQkEeOHMYoaBx8dPTNHOgSJSJ9BpHX2AE8BCQAFwFzDSzaWZ2hZm1qUUNfwDGAouBm4BrgPnALcDXO+r6K7Gtc4sU7jttCAvW5THuFQ3DLhJNIj7d5Jz7zjl3GdAR7+jjbWAAcA/eUchrZnZ8BC/5P6CLc+4M59z9zrmHnHOnAv8ABqLhS+LWvru35apDe/HazJ947Mtsv8sRkbBaX6dwzpU45152zh0LdAKuBOYAx+KFQU1fJ8s5l1vFphfCy/61rVGavksP2I0j+3fg1nd+5LMFOX6XIyLU30ROG4Af8O4sL6F+hh3pEl5q0oY4FggYd44aRO8O6Yx5bjqL1m31uySRuFen4DCzPmZ2G7AceA84HVgGXF/H1w2GX6MU0Pweca5ZYoiJZw8jKRTggie/Y8XGAr9LEolrEQeHmbU0s0vNbAreUcZf8CZyegzYxznXyzn3jzrWdQ+wF3C9c27+Duq4yMyyzCwrJ0enMGJdl5bNePisYazOLWT/f3/KZc9NZ+aKzX6XJRKXLJLeKmb2P+BovB5VDvgYeAJvqPXCeinI7Gbgb8Ajzrk/1uQ5mZmZLisrqz7eXqLcmtxCnvh6Kc9OWUZeYSlnjOjGTcf1JxjQoMwikTKzac65zIifF2FwlON1lX0SeNo5tyrSN9zJ698AjAceB853NSxOwRF/thaVcu9HC5j4RTaH92vPvaOHkJwQ9LsskSaltsER6amq3znn+jrn/tkAoTEeLzSeAi6oaWhIfEpLCnHdUXtw/dF78P4Pazl70lRyt5X4XZZIXIj0BsBvG6IIM7seuAF4GjjPOaehUaVG/rDPLtw7ejAzlm/i/Ce+o7CkzO+SRGJepDMA1jszuwy4Ea9n1kfA6Wa/Ol+91jn3oR+1SdNw3ODOBAPGmOdm8JeXv+eeUwez3e+QiNQj34MDGB5edsO7drK9zwAFh1Tr6IGdWLahgH+/P5/urVO58tBefpckErN8Dw7n3LnAuT6XITHg0gN2JXt9Pvd9vJBd2jTjhCFddv4kEYmYhkaXmGFm3HrCAPbq2Yq/vDxb93mINBAFh8SUxFCAB84YRrvmSVz89DTW5dXL7UUiUomCQ2JOq9REHjkrk9xtJVzyzHSKStXTSqQ+KTgkJu3RKZ07ThnEtGWbuPHNuX6XIxJTFBwSs44a2JGL99+V56Ys541ZP/ldjkjMUHBITLvqsF4M696Sca/MZvkGjaorUh8UHBLTEoIB7h09mIDBmOenU1yqQQlE6krBITGvS8tm3H7yQL5fmcs/353ndzkiTZ6CQ+LCEf07cu7vejDpq2zu+WiB3+WINGm+3zku0lj+fvQebC0q5Z6PFuIcjNWwJCK1ouCQuBEMGLefNBAD7v14Ic45xh7aSwMiikRIwSFxJRAw/nXSQAJm3PfJInK3lTD+mH4ENIOgSI0pOCTuBALGbScOID0lxMQvstmQX8ydowaRFNIMgiI1oeCQuBQIGNcdtQdt0pK47d155G4r4dFzMhUeIjWgXlUS1/64/67cftJAvli4ntvfm+93OSJNgoJD4t6o4V05e+/uPPZlNp/OW+d3OSJRT8EhAowb2Zc+HZpz9UuzWLdFQ7GLVEfBIQIkJwSZcPoQ8otLGfviTMrKnd8liUQtBYdI2G7tmnPDMf34atEGrn5pFqVlGtdKpCrqVSVSyeg9u7F+axF3fLCAotIy7jl1CIkh/X0lUpmCQ2Q7Yw7aneSEILe8/SPFpdOYcPpQkhPUTVekgv6UEqnCBfv25Obj+/PRj+u48KksthVr+lmRCgoOkR04a6/u3H7SQL5ctJ7znphKflGp3yWJRAUFh0g1Rg3vyj2nDua7pZs467EpbCks8bskEd8pOER24rjBnZlw2hBmr8pl1EPfsCZX93lIfFNwiNTAkQM6Munc4azctI0TH/iKBWvz/C5JxDcKDpEa2nf3trzwx70oKXec/ODXfLYgx++SRHyh4BCJQL9OGbx66e/okJHMOZOmMu7V2WzVRXOJMwoOkQh1admMN8bsw0X79eT5qcs54p7P+XbJBr/LEmk0Cg6RWkhOCDJuZF9e+uPehALGaRO/5Y7351OiYUokDig4ROogs0cr3r5iX04e2oUJny5i1MPfMPenLTinQRIldlks/IJnZma6rKwsv8uQOPfmrJ8Y98ps8opKaZWayPAeLRk5oCPHDuqEmeY0l+hjZtOcc5mRPk9jVYnUk2MGdWJEz1ZMnpfDlOyNTMnewPs/rOXzBeu55fj+pCRqvCuJDQoOkXrUrnkyo4Z3ZdTwrpSXO+79eCH3fbKQuau38NCZQ+neOtXvEkXqTNc4RBpIIGCMPbQXk84ZzqpNBYy89wsmfr5EF9ClyVNwiDSwA/u04+0r9mVEz9b8450fOfLeL/h60Xq/yxKpNQWHSCPo2qoZk84dzmPnZFJcWs7pj07h8a+y/S5LpFYUHCKN6OC+7flg7H4c3q89N745lzven6+uu9LkKDhEGllyQpAHzhjGaXt2ZcKni7j2ldkUl+q6hzQd6lUl4oNgwLj1hAG0Tk1iwqeLmLUylztPGcQendL9Lk1kp3TEIeITM+Pqw3vz6NmZ5OQVcdx/vmTCJwspKtU0tRLdFBwiPjtkj/Z8OHY/DuvXgTs+WMD+t09m0pfZmudcopaGHBGJIl8uXM/9nyxkSvZGWqcmcsaIbpw+ojsdMpL9Lk1iUG2HHFFwiESh75Zu5MHJi/l0/joCZhy2R3vOGNGd3+3amkBA415J/dBYVSIxZHiPVgw/txXLNxTw7JRlvJC1gnfnrKFbq2aM3rMrJw/tQrt0HYWIP3TEIdIEFJaU8d6cNTw/dTlTsjcSMG8q2xOHdubgvu1JS9LfgBI5napScEicWJyzlVenr+LVGatYtXkbZrB7uzQGdmnB4K4tyOzRkt3bNSeoU1qyEwoOBYfEmfJyx3dLN/LNkg18vzKXWSs2syG/GIDmSSH23KUVRw7oyKF7tCcjJcHnaiUa6RqHSJwJBIwRPVszomdrAJxzLN9YQNbSTWQt28TnC3L4eN46EoLGXj1bM7hrC/p3zmBglww6ZqT4XL00ZQoOkRhhZnRvnUr31qmcNKwLzjlmrczlndmr+XxBDg9MXkxZuXeGoUN6MkO6tWBot5YM6eYFSnKCJpqSmtGpKpE4UVhSxtzVW/h+xWZmrNjM9OWbWLFxGwAJQWOPjun8brc27N+rLcO6tyQhqPuDY52ucSg4RCKWk1fEjOWbmLFiM1lLNzJj+WZKyx2piUH6dEynZ5tUdmmbimHkbishd1sxqYkhurdJpUfrZnRITyYjJYH0lAQdsTRBCg4Fh0id5RWW8PXiDXy1aD0L1uaxOCefnLwiwDsqyUhJJK+whKIqRvNNTQzSISOZjhkptElLJCUxREpCkGaJQdJTQqQnJ/wcMunJCaQkBtmwtYg1WwrJySsiNSlE69REWqcl0Tz5l+e2aJaoHmINRBfHRaTOmicncHi/Dhzer8PP67YWlRIwSEkIYmaUlzvW5RWxdEM+6/KKyN1WwpZtJazfWsTaLYWszi1k+fICtpWUsa24jILiUsrr8PdpMGB0SE+mc0svkFITQ6QmhUhNCpKSECQ5IUhKYpC0pBCpiSECAVi7pYg1uYXkbishNSlIenICzZMTSAgaCcEACcEASaEAKYne89umJdEhI5nEkE7P1YSCQ0Sqtf3NhYGA0SEjucbjZznnyC8uY8u2kp9DZkthKQXFpbRKTaRjRjJt05IpKCllw9Zi1m8tYmtRKQXFZRQUlZKztYhVm7axavM25q/JI7+ojPyiUvJ3EkhmXrfk/OKynzsFVMcM2qQlkZYUIhQwggEjJTFI8+QEmieFSEsK0SwpSGpiiMRQAAs/JyEYIC3Z254QDLBuSyGrtxSyKb+Y5IQgqUkV234JrWaJQZoleuGXFAoSChqJwQCJocDPy7TkEM2TQphF39GWgkNEGpSZkRb+8OzUYsfdgDNIiKibsHOOkjJHYal3ZLO1qJT8olLKyh3t05Np2zyJhGAA5xwFxWXkFZZSUlYefjiKws/bVlLGurwiVm8uZHXuNgqKyygt9/YpLCkjd1sJKzcVkF9USkFR2U4DC7zTei2bJVJUWk5+USmltTzkSggaLZolkpYUwoxwWBnlzuEclDvHB2P3IynUuNeXFBwi0iSZGYkhIzEUID05gfbV7Oed2qqfjzvnHGXlDgc4ByVl5WwtKv05mNo2T6JVs8SfB6N0zlEcDquSUi+4tpWU/XxUVVxa7m0PL4tLvcfWolI25hezMb+Y/OIyXDgsHI6AWfgBRuMfkfgeHGYWAP4E/BHoAeQALwLXO+fyfSxNROQ3zIxQ8JcP68RQgNSkEO13MHmjmZEUCpIUApIap8aGFg1Xgu4G7gLmApcDLwFXAG+GQ0VERKKIr0ccZtYPLyxecc6dVGl9NnAfMBp4zqfyRESkCn7/RX8a3vWee7ZbPxEoAM5s7IJERKR6fgfHcKAcmFp5pXOuEJgZ3i4iIlHE7+DoBKx3zhVVsW0V0MbMEqt6opldZGZZZpaVk5PToEWKiMgv/A6OZkBVoQFQWGmf33DOPeKcy3TOZbZt27ZBihMRkd/yOzgK2HEHteRK+4iISJTwOzh+wjsdVVV4dMY7jVXcyDWJiEg1/L4B8DvgMGBP4IuKlWaWDAwGPq/Ji0ybNm29mS2rZQ1tgPW1fG5TpnbHF7U7vtS03d1r8+J+B8cLwDjgz1QKDuBCvGsbz9bkRZxztb7IYWZZtRlWuKlTu+OL2h1fGrrdvgaHc262mf0HGGNmrwDvAH3x7hz/DN38JyISdfw+4gDvaGMpcBFwFN7h1f14Y1X9drYYERHxle/B4ZwrA+4MP/zwiE/v6ze1O76o3fGlQdsdE1PHiohI4/G7O66IiDQxCg4REYmIgkNERCISd8FhZgEzG2tm88ys0MxWmNmdZpbqd231wcx6mdlNZvatmeWYWZ6ZzTSz66pqo5n1NrPXzGyTmeWb2RdmdpAftdc3M2tmZtlm5sxsQhXbY6btZtbKzO4ws0Xh3+scM/vUzPbdbr9YanOamY0zs9nh3/P1Zva1mZ1rZrbdvk2u3WZ2rZm9ZGZLwr/DS3eyf43bWOfPQW8e2/h5APcCDngF70bDu4AS4BMg4Hd99dC+fwJ5eDdPXg5cjHejpQNmASmV9t0V2ACsBa4FLgVmhL8fh/jdlnr4XtwR/l44YMJ222Km7Xh3/2bjTbv8T+APwFjgcWB0jLY5gHfTcBkwCa87/5+BKeGf97+aervD7dgAfAhsBJZWs29Ebazr56Dv35xG/kH0w5v/4+Xt1l8e/iae7neN9dDGTCCjivW3hNs4ptK6F8P/8QZXWpcGLAPmE+511xQfwFCgFLhyB8ERM20Pf4CuADruZL9YavPe4Z/r3dutTwSWAJuberuBnpX+PWcnwVHjNtbH52C8naqK+RkHnXNZzrncKja9EF72Bwgfkh4LTHbOzaz0/K3Ao0AvmuhEWmYWxPuZvof3F9X222Om7Wa2H7APcLtzbrWZJZjZb6YiiKU2h6WHlz9VXum8QVHXA/nQtNvtnFtSk/1q0cY6fw7GW3DE84yDXcLLteHlQLwh7b+pYt9vw8um+v0YC/QBxuxgeyy1fWR4udzM3gS2AflmtsDMKn8AxFKbwfs/vBn4PzM7xcy6hc/x3wYMA24I7xdr7a5KpG2s8+dgvAVHrWccbMrCf4Ffj3fqpmL8r07h5aoqnlKxrnMDl1bvzGwX4EbgJufc0h3sFktt7x1eTgRaAecA5wPFwNNmdl54eyy1GefcJry/sjfinaZZBswDLgNOcs5NDO8aU+3egUjbWOfPQd+HHGlkNZ1xMNbmALkH2AsY55ybH15XcTqjqu9HtbMvRrkH8S4U31XNPrHU9ubhZR5wYPhUDWb2Kt65/lvN7Eliq80VtuKd+38D+BovOC8DnjOz45xzHxKb7d5epG2s8+dgvAVHAdBuB9ticsZBM7sZ75TNI8652yptqmhnVZNoNcnvRfjUzGHAfs65kmp2jaW2bwsvn3eVJj1zzm0yszeAs/GOSmKpzZjZALywGOuce6jS+ufxwmSime1KjLV7ByJtY50/B+PtVFVczThoZjcAf8PrlnnxdpsrLipWdZhesa6qQ9+oFP6Z3oU3NP8aM9vNzHbjl4lqMsLrWhBbbV8ZXq6pYtvq8LIlsdVm8K5jJQMvVV7pnCsA3sb7ufcg9tpdlUjbWOfPwXgLju/w2rxn5ZWVZhzM8qGmBmFm44HxwFPABS7c366S2XiHq3tX8fS9wsum9P1IAdriDc2/sNJjcnj7meGvLyC22l5xgbNLFdsq1q0jttoMv3wgBqvYFqq0jLV2VyXSNtb9c9DvvsqN3C96ANX3Xz7T7xrrqZ3Xh9vzFNXczIP311oZMKjSuoq+3wuI0v7tO2hLAnByFY9Lwt+Ld8Nf94qltuMdTWzBO/JIq7S+I941gAUx+vO+O/xz/b/t1rfA+4t6IxCKlXaz8/s4atzG+vgcjLth1c3sfrxz/q/y6xkHvwIOck188igzuwyYACwH/o73C1LZWuddNCR8Kmcq3h2jd+N9AF2I94t1lHPu/caqu6GYWQ+8i+X/cc6NqbQ+ZtpuZhcBDwM/4N1FnYgXmB2Bo51zH4T3i6U2dwem4wXns3j/f1vhtacHcJlz7oHwvk2y3WZ2Fr+car0c7+daMW/RMufc05X2jaiNdf4c9DtJfUjuIHAV3t2URXjn/u6i0l9rTfkBPIH3V8OOHpO3278v8Dpen/gC4EuieBiGWnw/elDFneOx1nbgRLw++/l4Paw+AH4f423eFXgS72irJPxh+TlwYiy0G+80a43+H0faxrp+DsbdEYeIiNRNvF0cFxGROlJwiIhIRBQcIiISEQWHiIhERMEhIiIRUXCIiEhEFBwiIhIRBYdIDZjZAWbmwgNHisQ1BYdImJn1CIfDE37XIhLN4m0+DpHamoo3pMN6vwsR8ZuCQ6QGnDfPwzy/6xCJBjpVJcLPk15lh788J3zKquJx7o6ucZjZ5PD6BDO73swWm1mhmc0zswsr7Xexmc02s21mttLMbjSzKv//mdkIM/ufma0xs2IzW2FmD5tZp6r2F2lsOuIQ8UzGm8vhT8As4LVK22aGt1Xnv8AIvCGqS/Dm/njEzEqAgcA5wFvAx8CxeHOmFAD/qvwiZnYeMBFvxNI3gBXA7ngTUB1jZns555bXpoEi9UWj44qEVZq740nn3LnbbTsA+BS40Tl3Q6X1k4H98WZNO9Q5tzm8vifeqa18vGGu93HOrQpvawEswhseu6NzrjS8vhfehD3Lgf0r9g9vOwj4EHjDOXdC/bVaJHI6VSVSP/5aERoAzrklePMhtABurhwC4f3eBNrw63miL8GbyfBPlfcPP+cTvCOQY8ysecM0QaRmdKpKpH5UNU/zT+HltCq2VQRDF7zpPeGXOaP3N7PhVTynHd4EPL128JoijULBIVIPnHO5VawuDS+r25ZQaV3r8PKanbxdWgSlidQ7BYdI9KgImAzn3BZfKxGphq5xiPyiLLwM+vT+34aX+/r0/iI1ouAQ+cUmvJ5O3Xx6/wl4XXnvDvew+hUzSzQzhYr4TqeqRMKcc1vNbAqwr5k9CyzAOwp5o5Hef56Z/QGYBPxgZu+Fa0jAC7N9gRygT2PUI7IjCg6RXzsLuBs4AjgNMGAlsLQx3tw594yZzQKuAg4EDsO7F+Qn4H/AC41Rh0h1dAOgiIhERNc4REQkIgoOERGJiIJDREQiouAQEZGIKDhERCQiCg4REYmIgkNERCKi4BARkYgoOEREJCL/D70iv8DvEU6QAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ds.volume.plot()\n",
     "# the glacier will be almost gone in that climate "
@@ -2266,7 +2245,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "c8b02129",
+   "id": "a5d2b727",
    "metadata": {},
    "outputs": [
     {
@@ -2311,7 +2290,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "9ec1633c",
+   "id": "7d007573",
    "metadata": {},
    "outputs": [
     {
@@ -2345,7 +2324,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "955bd411",
+   "id": "a1c2b456",
    "metadata": {},
    "outputs": [
     {
@@ -2376,7 +2355,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "d2188468",
+   "id": "41559708",
    "metadata": {},
    "outputs": [
     {
@@ -2405,7 +2384,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "ffd2ba40",
+   "id": "f1a15bb7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2428,7 +2407,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "7c623578",
+   "id": "04bec5f8",
    "metadata": {},
    "outputs": [
     {
@@ -2454,14 +2433,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10f8a3e3",
+   "id": "893acc72",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "920f3bce",
+   "id": "1329babd",
    "metadata": {},
    "source": [
     "# now do the workflow of Sarah: \n",
@@ -2472,7 +2451,7 @@
   {
    "cell_type": "code",
    "execution_count": 129,
-   "id": "80f8c65d",
+   "id": "06b85b11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2484,7 +2463,7 @@
   {
    "cell_type": "code",
    "execution_count": 130,
-   "id": "ba0ba11b",
+   "id": "50a745c2",
    "metadata": {},
    "outputs": [
     {
@@ -2528,7 +2507,7 @@
   {
    "cell_type": "code",
    "execution_count": 131,
-   "id": "2a9674ce",
+   "id": "77d3865c",
    "metadata": {},
    "outputs": [
     {
@@ -2579,7 +2558,7 @@
   {
    "cell_type": "code",
    "execution_count": 132,
-   "id": "8aee3bfc",
+   "id": "a23891a8",
    "metadata": {},
    "outputs": [
     {
@@ -2613,7 +2592,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c397e988",
+   "id": "44345393",
    "metadata": {},
    "source": [
     "# run the climate "
@@ -2622,7 +2601,7 @@
   {
    "cell_type": "code",
    "execution_count": 133,
-   "id": "93167b0f",
+   "id": "ee314643",
    "metadata": {},
    "outputs": [
     {
@@ -2683,7 +2662,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f35d587",
+   "id": "02060849",
    "metadata": {},
    "source": [
     "- does this make sense that runoff rather increases, because peak water has been reached at some time between 2010 and 2020 ??? "
@@ -2692,7 +2671,7 @@
   {
    "cell_type": "code",
    "execution_count": 134,
-   "id": "6b21ae8a",
+   "id": "a7d1d0a6",
    "metadata": {},
    "outputs": [
     {
@@ -2728,7 +2707,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b9165cd5",
+   "id": "b4adf625",
    "metadata": {},
    "source": [
     "- depending on which prcp-fac, the spin-up is not sufficient and we could apply a negative temp. bias because initial volume in 1980 should be well above the rgi_date,\n",
@@ -2739,7 +2718,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a37f12f0",
+   "id": "1cfdbb2a",
    "metadata": {},
    "source": [
     "# some precipitation analysis"
@@ -2748,7 +2727,7 @@
   {
    "cell_type": "code",
    "execution_count": 135,
-   "id": "aa9ff33a",
+   "id": "10cea3e7",
    "metadata": {},
    "outputs": [
     {
@@ -3140,7 +3119,7 @@
   {
    "cell_type": "code",
    "execution_count": 136,
-   "id": "afa49e2f",
+   "id": "80f1cf72",
    "metadata": {},
    "outputs": [
     {
@@ -3559,7 +3538,7 @@
   {
    "cell_type": "code",
    "execution_count": 137,
-   "id": "8bb6d35d",
+   "id": "de01c74d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3594,7 +3573,7 @@
   {
    "cell_type": "code",
    "execution_count": 138,
-   "id": "3b6c76b0",
+   "id": "76d8486b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3604,7 +3583,7 @@
   {
    "cell_type": "code",
    "execution_count": 139,
-   "id": "20a3255f",
+   "id": "627f607f",
    "metadata": {},
    "outputs": [
     {
@@ -3638,7 +3617,7 @@
   {
    "cell_type": "code",
    "execution_count": 140,
-   "id": "a28f0dd2",
+   "id": "7e8a447d",
    "metadata": {},
    "outputs": [
     {
@@ -4033,7 +4012,7 @@
   {
    "cell_type": "code",
    "execution_count": 141,
-   "id": "a5a64ecc",
+   "id": "5f48200c",
    "metadata": {},
    "outputs": [
     {
@@ -4411,7 +4390,7 @@
   {
    "cell_type": "code",
    "execution_count": 142,
-   "id": "878ea5c2",
+   "id": "4b9b08a8",
    "metadata": {},
    "outputs": [
     {
@@ -4432,7 +4411,7 @@
   {
    "cell_type": "code",
    "execution_count": 143,
-   "id": "9662fa48",
+   "id": "c392184b",
    "metadata": {},
    "outputs": [
     {
@@ -4809,7 +4788,7 @@
   {
    "cell_type": "code",
    "execution_count": 47,
-   "id": "03227982",
+   "id": "2e1d78fe",
    "metadata": {},
    "outputs": [
     {
@@ -4829,7 +4808,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c22dfc9",
+   "id": "5112a31a",
    "metadata": {},
    "source": [
     "- need possibly higher prcp-fac for W5E5 and W5E5_MSWEP than for WFDE5_CRU in case of HEF! How is it for the Rhine basin or total Alps?"
@@ -4838,7 +4817,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49a186a1",
+   "id": "61621a7a",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
- adapted run_from_... that ref_hgt correction of 'melt_f_calib_geod_prep_inversion'  works 
-> also a small test in `test_melt_f_calib_geod_prep_inversion` added

- quality check in run_from_climate/random/constant still applied if we do not use the `melt_f_calib_geod_prep_inversion`  workflow!!!

- some tests did not work anymore because the cfg.PARAMS['hydro_month_nh'] is not anymore default 10, so added cfg.PARAMS['hydro_month_nh']=10 to some of the tests 

- one test still fails (`test_daily_monthly_annual_specific_mb`) because sarah needs `get_daily_mb` in such a way that it accounts for leap years,  so doy are not 365.25 as in get_annual_mb but the amount of days of the year in reality!!!

- another test fails because `run_with_hydro_daily` only works at the moment with an adapted oggm version!