### PR TITLE
new minimize_geodetic_via_temp_bias+test and no_qc run option

### DIFF
--- a/MBsandbox/flowline_TIModel.py
+++ b/MBsandbox/flowline_TIModel.py
@@ -51,6 +51,7 @@ def run_from_climate_data_TIModel(gdir, ys=None, ye=None, min_ys=None,
                                   mb_model_sub_class=TIModel,
                                   kwargs_for_TIModel_Sfc_Type={},
                                   reset=True,
+                                  no_qc=False,
                                   **kwargs):
     """ Runs a glacier with climate input from e.g. W5E5 or a GCM.
 
@@ -125,6 +126,9 @@ def run_from_climate_data_TIModel(gdir, ys=None, ye=None, min_ys=None,
     precipitation_factor: float
         multiply a factor to the precipitation time series
         use the value from the calibration!
+    no_qc : boolean
+        default is False (so qc is done if melt_f comes not from json).
+        but can be set to True if no quality check is wanted when melt_f is set directly!
     kwargs : dict
         kwargs to pass to the FluxBasedModel instance
     """
@@ -215,8 +219,9 @@ def run_from_climate_data_TIModel(gdir, ys=None, ye=None, min_ys=None,
             np.testing.assert_allclose(ref_hgt_calib_diff,
                             mb.flowline_mb_models[-1].ref_hgt - mb.flowline_mb_models[-1].uncorrected_ref_hgt)
     else:
-        # do the quality check!
-        mb.flowline_mb_models[-1].historical_climate_qc_mod(gdir)
+        if not no_qc:
+            # do the quality check!
+            mb.flowline_mb_models[-1].historical_climate_qc_mod(gdir)
 
     if ye is None:
         # Decide from climate (we can run the last year with data as well)
@@ -258,6 +263,7 @@ def run_random_climate_TIModel(gdir, nyears=1000, y0=None, halfsize=15,
                                zero_initial_glacier=False,
                                unique_samples=False, #melt_f_file=None,
                                reset = True,
+                               no_qc=False,
                                kwargs_for_TIModel_Sfc_Type={},
                                **kwargs):
 
@@ -332,6 +338,9 @@ def run_random_climate_TIModel(gdir, nyears=1000, y0=None, halfsize=15,
         per random climate period-length
         if false, every model year will be chosen from the random climate
         period with the same probability
+    no_qc : boolean
+        default is False (so qc is done if melt_f comes not from json).
+        but can be set to True if no quality check is wanted when melt_f is set directly!
     kwargs : dict
         kwargs to pass to the FluxBasedModel instance
     """
@@ -384,8 +393,9 @@ def run_random_climate_TIModel(gdir, nyears=1000, y0=None, halfsize=15,
         np.testing.assert_allclose(ref_hgt_calib_diff,
                         mb.flowline_mb_models[-1].mbmod.ref_hgt - mb.flowline_mb_models[-1].mbmod.uncorrected_ref_hgt)
     else:
-        # do the quality check!
-        mb.flowline_mb_models[-1].historical_climate_qc_mod(gdir)
+        if not no_qc:
+            # do the quality check!
+            mb.flowline_mb_models[-1].historical_climate_qc_mod(gdir)
 
     if init_model_fls is None:
         fls = gdir.read_pickle('model_flowlines')
@@ -436,6 +446,7 @@ def run_constant_climate_TIModel(gdir, nyears=1000, y0=None, halfsize=15,
                                  reset = True,
                                  interpolation_optim=False,
                                  use_avg_climate=False,
+                                 no_qc=False,
                                  **kwargs):
     """Runs the constant mass-balance model of the TIModel
      for a given number of years.
@@ -508,6 +519,9 @@ def run_constant_climate_TIModel(gdir, nyears=1000, y0=None, halfsize=15,
         to change these params: melt_f_ratio_snow_to_ice, melt_f_update, spinup_yrs,
         tau_e_fold_yr, melt_f_change; if mb_model_sub_class is TIModel, this should be
         an empty dict!
+    no_qc : boolean
+        default is False (so qc is done if melt_f comes not from json).
+        but can be set to True if no quality check is wanted when melt_f is set directly!
     kwargs : dict
         kwargs to pass to the FluxBasedModel instance
     """
@@ -576,8 +590,9 @@ def run_constant_climate_TIModel(gdir, nyears=1000, y0=None, halfsize=15,
                                    mb.flowline_mb_models[-1].mbmod.ref_hgt - mb.flowline_mb_models[
                                        -1].mbmod.uncorrected_ref_hgt)
     else:
-        # do the quality check!
-        mb.flowline_mb_models[-1].historical_climate_qc_mod(gdir)
+        if not no_qc:
+            # do the quality check!
+            mb.flowline_mb_models[-1].historical_climate_qc_mod(gdir)
 
     if init_model_fls is None:
         fls = gdir.read_pickle('model_flowlines')

--- a/MBsandbox/tests/test_mb_modules_oneflowline.py
+++ b/MBsandbox/tests/test_mb_modules_oneflowline.py
@@ -990,6 +990,65 @@ class Test_geodetic_hydro1:
         assert_allclose(melt_fs[0], melt_fs[1], rtol= 0.2)
         assert_allclose(melt_fs[0], melt_fs[2], rtol= 0.2)
 
+    def test_minimize_geodetic_via_temp_bias(self, gdir):
+        from MBsandbox.help_func import (minimize_bias_geodetic_via_temp_bias)
+        cfg.PARAMS['hydro_month_nh'] = 1
+
+        grad_type = 'cte'
+        N = 100
+        # get the geodetic calibration data
+        url = 'https://cluster.klima.uni-bremen.de/~oggm/geodetic_ref_mb/hugonnet_2021_ds_rgi60_pergla_rates_10_20_worldwide.csv'
+        path_geodetic = utils.file_downloader(url)
+        pd_geodetic_all = pd.read_csv(path_geodetic, index_col='rgiid')
+        pd_geodetic = pd_geodetic_all.loc[pd_geodetic_all.period == '2000-01-01_2020-01-01']
+        mb_geodetic = pd_geodetic.loc[gdir.rgi_id].dmdtda * 1000
+
+        melt_f_opt_ref, pf_opt_ref = (160, 2.7) # just approximate values from the optimal ref
+        for mb_type in ['mb_monthly', 'mb_pseudo_daily', 'mb_real_daily']:
+
+            for climate_type in ['W5E5']:
+
+                if mb_type != 'mb_real_daily':
+                    temporal_resol = 'monthly'
+                    process_w5e5_data(gdir, climate_type=climate_type,
+                                      temporal_resol=temporal_resol)
+                    input_fs = '_monthly_W5E5'
+                else:
+                    # because of get_climate_info need ERA5_daily as
+                    # baseline_climate until WFDE5_daily is included in
+                    # get_climate_info
+                    # cfg.PARAMS['baseline_climate'] = 'ERA5_daily'
+                    temporal_resol='daily'
+                    process_w5e5_data(gdir, climate_type=climate_type,
+                                      temporal_resol=temporal_resol)
+                    input_fs = '_daily_W5E5'
+
+                hgts, widths = gdir.get_inversion_flowline_hw()
+                fs = '_{}_{}'.format(temporal_resol, climate_type)
+                mbdf = gdir.get_ref_mb_data(input_filesuffix=fs)
+                ys_glac = mbdf.index.values
+                gd_mb = TIModel(gdir, None, prcp_fac=1,
+                                mb_type=mb_type,
+                                grad_type=grad_type,
+                                N=N, baseline_climate=climate_type)
+
+                temp_bias = scipy.optimize.brentq(minimize_bias_geodetic_via_temp_bias, -3, 3,
+                                                      disp=True, xtol=0.01,
+                                                      args=(gd_mb, mb_geodetic,
+                                                            hgts, widths,
+                                                            melt_f_opt_ref, pf_opt_ref))
+                gd_mb.temp_bias = temp_bias
+                gd_mb.prcp_fac = pf_opt_ref
+                gd_mb.melt_f = melt_f_opt_ref
+
+                mb_specific = gd_mb.get_specific_mb(heights=hgts, widths=widths,
+                                                    year=np.arange(2000, 2020, 1))
+
+                bias = mb_specific.mean() - mb_geodetic
+                # check if the bias is optimised
+                assert bias.round() == 0
+
+
     def test_daily_monthly_annual_specific_mb(self, gdir):
         # this does not work because of different days of years at the moment!!!
         # for both ERA5 and WFDE5


### PR DESCRIPTION
- option to tune the temp. bias to match the geodetic estimates when both pf and melt_f are given (in experimental phase)
- added option to not use the quality check when not using the melt_f from json import for the run_from_climate/random/cte functions