### PR TITLE
some minor changes + update geodetic notebook

### DIFF
--- a/MBsandbox/mbmod_daily_oneflowline.py
+++ b/MBsandbox/mbmod_daily_oneflowline.py
@@ -4083,6 +4083,8 @@ def compile_fixed_geometry_mass_balance_TIModel(gdirs, filesuffix='',
         end year of the model run (default: from the climate file)
     years : array of ints
         override ys and ye with the years of your choice
+    kwargs :
+        passed to fixed_geometry_mass_balance_TIModel
     todo: other docs!
     """
     from oggm.workflow import execute_entity_task

--- a/docs/geodetic_mb_calibration_to_volume_changes.ipynb
+++ b/docs/geodetic_mb_calibration_to_volume_changes.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7c5dca5f",
+   "id": "6897c59e",
    "metadata": {},
    "source": [
     "# Workflow to calibrate OGGM with geodetic data and run volume projections with your own climate dataset!"
@@ -10,17 +10,17 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b9962c6f",
+   "id": "31bc5d22",
    "metadata": {},
    "source": [
-    "- We basically do what `run_prepro_levels` of prepro_levels.py (->link) would do if `start_level=2` and if we use `match_geodetic_mb_per_glacier=True`\n",
+    "- We basically do what `run_prepro_levels` of [prepro_levels.py](https://github.com/lilianschuster/oggm/blob/240ec6001dab28d1f9ac4a684625d4c76ef8369a/oggm/cli/prepro_levels.py) would do if `start_level=2` and if we use `match_geodetic_mb_per_glacier=True`\n",
     "- here we use the W5E5 climate and a special glacier-specific precipitation factor"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "6f71722b",
+   "id": "fc45c7e6",
    "metadata": {},
    "outputs": [
     {
@@ -29,9 +29,9 @@
      "text": [
       "/home/lilianschuster/oggm/oggm/cfg.py:386: FutureWarning: In future versions of OGGM, the logging config WORKFLOW will no longer print ERROR or WARNING messages, but only high level information (i.e. hiding potential errors in your code but also avoiding cluttered log files for runs with many expected errors, e.g. global runs). If you want to obtain a similar logger behavior as before, set `logging_level='WARNING'`, which will print high level info as well as errors and warnings during the run. If you want to use the new behavior and suppress this warning, set `logging_level='WORKFLOW'` and `future=True`.\n",
       "  warnings.warn(msg, category=FutureWarning)\n",
-      "2022-05-30 16:52:03: oggm.cfg: Reading default parameters from the OGGM `params.cfg` configuration file.\n",
-      "2022-05-30 16:52:03: oggm.cfg: Multiprocessing switched OFF according to the parameter file.\n",
-      "2022-05-30 16:52:03: oggm.cfg: Multiprocessing: using all available processors (N=8)\n"
+      "2022-07-07 10:10:17: oggm.cfg: Reading default parameters from the OGGM `params.cfg` configuration file.\n",
+      "2022-07-07 10:10:17: oggm.cfg: Multiprocessing switched OFF according to the parameter file.\n",
+      "2022-07-07 10:10:17: oggm.cfg: Multiprocessing: using all available processors (N=8)\n"
      ]
     }
    ],
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0ed3e3a",
+   "id": "3f23f928",
    "metadata": {},
    "source": [
     "### 1. Initialize gdir and process your climate data"
@@ -69,24 +69,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "1cd315d5",
+   "execution_count": 50,
+   "id": "434cd91c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2022-05-30 16:52:03: oggm.cfg: PARAMS['baseline_climate'] changed from `CRU` to `GSWP3_W5E5`.\n",
-      "2022-05-30 16:52:03: oggm.cfg: PARAMS['climate_qc_months'] changed from `3` to `0`.\n",
-      "2022-05-30 16:52:03: oggm.cfg: PARAMS['hydro_month_nh'] changed from `10` to `1`.\n",
-      "2022-05-30 16:52:03: oggm.cfg: PARAMS['hydro_month_sh'] changed from `4` to `1`.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cfg.PARAMS['baseline_climate'] = 'GSWP3_W5E5'  # or W5E5 (if you just want data from 1979 onwards!)\n",
-    "\n",
+    "cfg.PARAMS['use_winter_prcp_factor'] = True\n",
     "match_geodetic_mb_per_glacier = True\n",
     "cfg.PARAMS['climate_qc_months'] = 0\n",
     "cfg.PARAMS['hydro_month_nh'] = 1\n",
@@ -96,16 +85,16 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "8bebe717",
+   "id": "722b997e",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-05-30 16:52:04: oggm.workflow: init_glacier_directories from prepro level 2 on 2 glaciers.\n",
-      "2022-05-30 16:52:04: oggm.workflow: Execute entity tasks [gdir_from_prepro] on 2 glaciers\n",
-      "2022-05-30 16:52:05: oggm.workflow: Execute entity tasks [process_climate_data] on 2 glaciers\n"
+      "2022-07-07 10:10:18: oggm.workflow: init_glacier_directories from prepro level 2 on 2 glaciers.\n",
+      "2022-07-07 10:10:18: oggm.workflow: Execute entity tasks [gdir_from_prepro] on 2 glaciers\n",
+      "2022-07-07 10:10:18: oggm.workflow: Execute entity tasks [process_climate_data] on 2 glaciers\n"
      ]
     },
     {
@@ -133,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c496a26",
+   "id": "1a9199d1",
    "metadata": {},
    "source": [
     "### 2. calibrate MB model of OGGM with geodetic estimates from Hugonnet et al. (2021)"
@@ -142,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "2ab4cd78",
+   "id": "b4d99400",
    "metadata": {},
    "outputs": [
     {
@@ -163,7 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "bfba1313",
+   "id": "0f6dcd8f",
    "metadata": {},
    "outputs": [
     {
@@ -184,7 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "5ac32b9c",
+   "id": "7b54dd8f",
    "metadata": {},
    "outputs": [
     {
@@ -205,7 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "09dce96b",
+   "id": "e23f8c15",
    "metadata": {},
    "outputs": [
     {
@@ -226,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "d8ca27db",
+   "id": "199e1ff2",
    "metadata": {},
    "outputs": [
     {
@@ -246,23 +235,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c57ca2cb",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
    "execution_count": 9,
-   "id": "fe931c42",
+   "id": "10408d36",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-05-30 16:52:05: oggm.cfg: PARAMS['max_mu_star'] changed from `10000.0` to `1000`.\n"
+      "2022-07-07 10:10:28: oggm.cfg: PARAMS['max_mu_star'] changed from `10000.0` to `1000`.\n"
      ]
     },
     {
@@ -456,14 +437,15 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "ac44d548",
+   "id": "6da2e818",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-05-30 16:52:06: oggm.workflow: Execute entity tasks [mu_star_calibration_from_geodetic_mb] on 2 glaciers\n"
+      "2022-07-07 10:10:28: oggm.cfg: PARAMS['use_winter_prcp_factor'] changed from `False` to `True`.\n",
+      "2022-07-07 10:10:28: oggm.workflow: Execute entity tasks [mu_star_calibration_from_geodetic_mb] on 2 glaciers\n"
      ]
     },
     {
@@ -478,14 +460,14 @@
     }
    ],
    "source": [
-    "# workflow.execute_entity_task(tasks.mu_star_calibration_from_geodetic_mb, gdirs)\n",
     "# Let's directly calibrate by using prcp. fac from winter prcp. match \n",
-    "workflow.execute_entity_task(tasks.mu_star_calibration_from_geodetic_mb, gdirs, prcp_fac='from_winter_prcp')\n"
+    "# this is done when switching use_winter_prcp_factor to True in the Params\n",
+    "workflow.execute_entity_task(tasks.mu_star_calibration_from_geodetic_mb, gdirs) #, prcp_fac='from_winter_prcp')\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2a28cefb",
+   "id": "0ec3b699",
    "metadata": {},
    "source": [
     "**just to visualize what is applied internally in `mu_star_calibration_from_geodetic_mb` if using prcp_fac='from_winter_prcp'**"
@@ -493,17 +475,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "503d30ea",
+   "execution_count": 55,
+   "id": "759e90b0",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7fbdbc4ef490>"
+       "<matplotlib.legend.Legend at 0x7fd64b37d130>"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -524,16 +506,17 @@
     "# this is used inside of mu_star_calibration_from_geodetic_mb:\n",
     "# from MB sandbox calibration to winter MB\n",
     "# using t_melt=-1, cte lapse rate, monthly resolution\n",
-    "a_log_multiplied = -1.0614\n",
-    "b_intercept = 3.9200\n",
     "def log_func(x, a, b):\n",
+    "    l0, l1 = cfg.PARAMS['winter_prcp_factor_range']\n",
+    "    a_log_multiplied, b_intercept = cfg.PARAMS['winter_prcp_factor_ab']\n",
+    "\n",
     "    r = a*np.log(x) +b\n",
     "    # don't allow extremely low/high prcp. factors!!!\n",
     "    if np.shape(r) == ():\n",
-    "        if r > 10:\n",
-    "            r = 10\n",
-    "        if r<0.1:\n",
-    "            r=0.1\n",
+    "        if r > l1:\n",
+    "            r = l1\n",
+    "        if r< l0:\n",
+    "            r= l0\n",
     "    else:\n",
     "        r[r>10] = 10\n",
     "        r[r<0.1] = 0.1\n",
@@ -542,7 +525,7 @@
     "winter_prcp_values = np.arange(0.1, 20,0.05)\n",
     "plt.plot(winter_prcp_values, log_func(winter_prcp_values, a_log_multiplied, b_intercept), label='fitted precipitation factor relation to winter\\nprecipitation (found from 115 reference\\nglaciers where winter MB was matched)')\n",
     "plt.ylabel('fitted precipitation factor')\n",
-    "plt.xlabel('mean daily winter precipitation (kg m-2 day-1)') # mean over 1979-2020\n",
+    "plt.xlabel('mean daily winter precipitation (kg m-2 day-1)') # mean over 1979-2019\n",
     "plt.legend()"
    ]
   },
@@ -553,7 +536,7 @@
     }
    },
    "cell_type": "markdown",
-   "id": "833e695e",
+   "id": "39405a26",
    "metadata": {},
    "source": [
     "--> **WHAT is done in MB sandbox:**\n",
@@ -567,7 +550,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c34b1b75",
+   "id": "8103fab8",
    "metadata": {},
    "source": [
     "**different prcp. factors were applied depending on the mean daily non-corrected winter prcp**"
@@ -575,24 +558,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "91b1f54a",
+   "execution_count": 56,
+   "id": "ff7bf0fc",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'rgi_id': 'RGI60-11.00897',\n",
+       "{'prcp_fac_from_winter_prcp': 3.357136316271367,\n",
+       " 'rgi_id': 'RGI60-11.00897',\n",
        " 't_star': nan,\n",
        " 'bias': 0,\n",
        " 'mu_star_per_flowline': [275.602034813723],\n",
        " 'mu_star_glacierwide': 275.602034813723,\n",
        " 'mu_star_flowline_avg': 275.602034813723,\n",
-       " 'mu_star_allsame': True,\n",
-       " 'prcp_fac_from_winter_prcp': 3.357136316271367}"
+       " 'mu_star_allsame': True}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -603,24 +586,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "8a997734",
+   "execution_count": 57,
+   "id": "2ef1dfef",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'rgi_id': 'RGI60-11.01450',\n",
+       "{'prcp_fac_from_winter_prcp': 1.7765151972292408,\n",
+       " 'rgi_id': 'RGI60-11.01450',\n",
        " 't_star': nan,\n",
        " 'bias': 0,\n",
        " 'mu_star_per_flowline': [303.6193835683732],\n",
        " 'mu_star_glacierwide': 303.6193835683732,\n",
        " 'mu_star_flowline_avg': 303.6193835683732,\n",
-       " 'mu_star_allsame': True,\n",
-       " 'prcp_fac_from_winter_prcp': 1.7765151972292408}"
+       " 'mu_star_allsame': True}"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -631,16 +614,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "2b6b80f1",
+   "execution_count": 58,
+   "id": "2635a860",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-05-30 16:52:07: oggm.utils: Applying global task compile_climate_statistics on 2 glaciers\n",
-      "2022-05-30 16:52:07: oggm.workflow: Execute entity tasks [climate_statistics] on 2 glaciers\n"
+      "2022-07-07 11:12:46: oggm.utils: Applying global task compile_climate_statistics on 2 glaciers\n",
+      "2022-07-07 11:12:46: oggm.workflow: Execute entity tasks [climate_statistics] on 2 glaciers\n"
      ]
     },
     {
@@ -649,24 +632,25 @@
        "rgi_id\n",
        "RGI60-11.00897    1.6994472904408453\n",
        "RGI60-11.01450     7.534467999810557\n",
-       "Name: winter_daily_mean_prcp_1979_2019, dtype: object"
+       "Name: 1979-2019_uncorrected_winter_daily_mean_prcp, dtype: object"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# added winter_daily_mean_prcp_1979_2019\n",
-    "clim_stats = utils.compile_climate_statistics(gdirs, winter_daily_mean_prcp=True)\n",
-    "clim_stats['winter_daily_mean_prcp_1979_2019']  # maybe should call that _uncorrected ???"
+    "clim_stats = utils.compile_climate_statistics(gdirs) #, winter_daily_mean_prcp=True)\n",
+    "fs = '1979-2019'\n",
+    "clim_stats[f'{fs}_uncorrected_winter_daily_mean_prcp'] "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "8fd3f58d",
+   "id": "ec2630d5",
    "metadata": {},
    "outputs": [
     {
@@ -756,11 +740,6 @@
        "      <td>1718.526178</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>winter_daily_mean_prcp_1979_2019</th>\n",
-       "      <td>1.6994472904408453</td>\n",
-       "      <td>7.534467999810557</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>1980-2010_aar</th>\n",
        "      <td>0.514153</td>\n",
        "      <td>0.612994</td>\n",
@@ -840,41 +819,84 @@
        "      <td>2675.840543</td>\n",
        "      <td>4624.473092</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1979-2019_uncorrected_winter_daily_mean_prcp</th>\n",
+       "      <td>1.6994472904408453</td>\n",
+       "      <td>7.534467999810557</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1980-2010_uncorrected_winter_daily_mean_prcp</th>\n",
+       "      <td>1.6477840371240344</td>\n",
+       "      <td>7.493937614128538</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "rgi_id                                RGI60-11.00897      RGI60-11.01450\n",
-       "rgi_region                                        11                  11\n",
-       "rgi_subregion                                  11-01               11-01\n",
-       "name                                 Hintereisferner                    \n",
-       "cenlon                                       10.7584             8.01919\n",
-       "cenlat                                       46.8003             46.5028\n",
-       "rgi_area_km2                                   8.036              82.206\n",
-       "glacier_type                                 Glacier             Glacier\n",
-       "terminus_type                       Land-terminating    Land-terminating\n",
-       "status                            Glacier or ice cap  Glacier or ice cap\n",
-       "flowline_mean_elev                       3026.878257         3075.263293\n",
-       "flowline_max_elev                        3612.846072         3954.701667\n",
-       "flowline_min_elev                        2455.169167         1718.526178\n",
-       "winter_daily_mean_prcp_1979_2019  1.6994472904408453   7.534467999810557\n",
-       "1980-2010_aar                               0.514153            0.612994\n",
-       "1980-2010_mb_grad                           9.526522           13.212507\n",
-       "1980-2010_ela_h                          3046.417922         3006.469706\n",
-       "1980-2010_avg_temp_ela_h                   -5.779841           -4.722549\n",
-       "1980-2010_avg_temp_mean_elev               -5.652834           -5.169708\n",
-       "1980-2010_avg_temp_max_elev                -9.461624          -10.886057\n",
-       "1980-2010_avg_temp_min_elev                -1.936724            3.649084\n",
-       "1980-2010_avg_tempmelt_ela_h                7.624674           12.354527\n",
-       "1980-2010_avg_tempmelt_mean_elev            8.040517            10.55039\n",
-       "1980-2010_avg_tempmelt_max_elev             0.557164            0.155585\n",
-       "1980-2010_avg_tempmelt_min_elev            25.076611           63.810977\n",
-       "1980-2010_avg_prcpsol_ela_h              2101.375745          3751.11978\n",
-       "1980-2010_avg_prcpsol_mean_elev          2069.482237         3852.069282\n",
-       "1980-2010_avg_prcpsol_max_elev           2650.837719         4622.010732\n",
-       "1980-2010_avg_prcpsol_min_elev           1346.537036         2005.218895\n",
-       "1980-2010_avg_prcp                       2675.840543         4624.473092"
+       "rgi_id                                            RGI60-11.00897  \\\n",
+       "rgi_region                                                    11   \n",
+       "rgi_subregion                                              11-01   \n",
+       "name                                             Hintereisferner   \n",
+       "cenlon                                                   10.7584   \n",
+       "cenlat                                                   46.8003   \n",
+       "rgi_area_km2                                               8.036   \n",
+       "glacier_type                                             Glacier   \n",
+       "terminus_type                                   Land-terminating   \n",
+       "status                                        Glacier or ice cap   \n",
+       "flowline_mean_elev                                   3026.878257   \n",
+       "flowline_max_elev                                    3612.846072   \n",
+       "flowline_min_elev                                    2455.169167   \n",
+       "1980-2010_aar                                           0.514153   \n",
+       "1980-2010_mb_grad                                       9.526522   \n",
+       "1980-2010_ela_h                                      3046.417922   \n",
+       "1980-2010_avg_temp_ela_h                               -5.779841   \n",
+       "1980-2010_avg_temp_mean_elev                           -5.652834   \n",
+       "1980-2010_avg_temp_max_elev                            -9.461624   \n",
+       "1980-2010_avg_temp_min_elev                            -1.936724   \n",
+       "1980-2010_avg_tempmelt_ela_h                            7.624674   \n",
+       "1980-2010_avg_tempmelt_mean_elev                        8.040517   \n",
+       "1980-2010_avg_tempmelt_max_elev                         0.557164   \n",
+       "1980-2010_avg_tempmelt_min_elev                        25.076611   \n",
+       "1980-2010_avg_prcpsol_ela_h                          2101.375745   \n",
+       "1980-2010_avg_prcpsol_mean_elev                      2069.482237   \n",
+       "1980-2010_avg_prcpsol_max_elev                       2650.837719   \n",
+       "1980-2010_avg_prcpsol_min_elev                       1346.537036   \n",
+       "1980-2010_avg_prcp                                   2675.840543   \n",
+       "1979-2019_uncorrected_winter_daily_mean_prcp  1.6994472904408453   \n",
+       "1980-2010_uncorrected_winter_daily_mean_prcp  1.6477840371240344   \n",
+       "\n",
+       "rgi_id                                            RGI60-11.01450  \n",
+       "rgi_region                                                    11  \n",
+       "rgi_subregion                                              11-01  \n",
+       "name                                                              \n",
+       "cenlon                                                   8.01919  \n",
+       "cenlat                                                   46.5028  \n",
+       "rgi_area_km2                                              82.206  \n",
+       "glacier_type                                             Glacier  \n",
+       "terminus_type                                   Land-terminating  \n",
+       "status                                        Glacier or ice cap  \n",
+       "flowline_mean_elev                                   3075.263293  \n",
+       "flowline_max_elev                                    3954.701667  \n",
+       "flowline_min_elev                                    1718.526178  \n",
+       "1980-2010_aar                                           0.612994  \n",
+       "1980-2010_mb_grad                                      13.212507  \n",
+       "1980-2010_ela_h                                      3006.469706  \n",
+       "1980-2010_avg_temp_ela_h                               -4.722549  \n",
+       "1980-2010_avg_temp_mean_elev                           -5.169708  \n",
+       "1980-2010_avg_temp_max_elev                           -10.886057  \n",
+       "1980-2010_avg_temp_min_elev                             3.649084  \n",
+       "1980-2010_avg_tempmelt_ela_h                           12.354527  \n",
+       "1980-2010_avg_tempmelt_mean_elev                        10.55039  \n",
+       "1980-2010_avg_tempmelt_max_elev                         0.155585  \n",
+       "1980-2010_avg_tempmelt_min_elev                        63.810977  \n",
+       "1980-2010_avg_prcpsol_ela_h                           3751.11978  \n",
+       "1980-2010_avg_prcpsol_mean_elev                      3852.069282  \n",
+       "1980-2010_avg_prcpsol_max_elev                       4622.010732  \n",
+       "1980-2010_avg_prcpsol_min_elev                       2005.218895  \n",
+       "1980-2010_avg_prcp                                   4624.473092  \n",
+       "1979-2019_uncorrected_winter_daily_mean_prcp   7.534467999810557  \n",
+       "1980-2010_uncorrected_winter_daily_mean_prcp   7.493937614128538  "
       ]
      },
      "execution_count": 15,
@@ -888,16 +910,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "b9b3933f",
+   "execution_count": 59,
+   "id": "a7a36b1f",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-05-30 16:52:07: oggm.utils: Applying global task compile_glacier_statistics on 2 glaciers\n",
-      "2022-05-30 16:52:07: oggm.workflow: Execute entity tasks [glacier_statistics] on 2 glaciers\n"
+      "2022-07-07 11:12:49: oggm.utils: Applying global task compile_glacier_statistics on 2 glaciers\n",
+      "2022-07-07 11:12:49: oggm.workflow: Execute entity tasks [glacier_statistics] on 2 glaciers\n"
      ]
     },
     {
@@ -982,6 +1004,26 @@
        "      <td>Glacier or ice cap</td>\n",
        "    </tr>\n",
        "    <tr>\n",
+       "      <th>inv_volume_km3</th>\n",
+       "      <td>0.577716</td>\n",
+       "      <td>13.753719</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>vas_volume_km3</th>\n",
+       "      <td>0.59691</td>\n",
+       "      <td>14.603981</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>inv_volume_bsl_km3</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>inv_volume_bwl_km3</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>dem_source</th>\n",
        "      <td>NASADEM</td>\n",
        "      <td>NASADEM</td>\n",
@@ -990,6 +1032,21 @@
        "      <th>flowline_type</th>\n",
        "      <td>elevation_band</td>\n",
        "      <td>elevation_band</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>apparent_mb_from_any_mb_residual</th>\n",
+       "      <td>1100.3</td>\n",
+       "      <td>1210.7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>inversion_glen_a</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>inversion_fs</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>error_task</th>\n",
@@ -1138,8 +1195,15 @@
        "terminus_type                          Land-terminating    Land-terminating\n",
        "is_tidewater                                      False               False\n",
        "status                               Glacier or ice cap  Glacier or ice cap\n",
+       "inv_volume_km3                                 0.577716           13.753719\n",
+       "vas_volume_km3                                  0.59691           14.603981\n",
+       "inv_volume_bsl_km3                                  0.0                 0.0\n",
+       "inv_volume_bwl_km3                                  0.0                 0.0\n",
        "dem_source                                      NASADEM             NASADEM\n",
        "flowline_type                            elevation_band      elevation_band\n",
+       "apparent_mb_from_any_mb_residual                 1100.3              1210.7\n",
+       "inversion_glen_a                                    0.0                 0.0\n",
+       "inversion_fs                                          0                   0\n",
        "error_task                                         None                None\n",
        "error_msg                                          None                None\n",
        "dem_mean_elev                                3028.33252         3071.166992\n",
@@ -1168,7 +1232,7 @@
        "prcp_fac_from_winter_prcp                      3.357136            1.776515"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1181,23 +1245,39 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5fedca6f",
+   "id": "8e4751b6",
    "metadata": {},
    "source": [
     "**can estimate fixed geometry**:\n",
     "\n",
-    "- remark: I put that before the ice thickness inversion because you don't need that for that (in prepro level, it is computed after ice thickness inversion)\n",
-    "- need loop here at the moment because prcp. fac not yet incorporated in `compile_fixed_geometry ...`\n",
-    "\n",
-    "    **--> instead could use the same approach as with `apparent_mb_from_any_mb`** (see below)\n"
+    "- remark: I put that before the ice thickness inversion because you don't need that for that (in prepro level, it is computed after ice thickness inversion) \n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "3c8b3972",
+   "execution_count": 60,
+   "id": "11de0da7",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-07-07 11:13:54: oggm.utils: Applying global task compile_fixed_geometry_mass_balance on 2 glaciers\n",
+      "2022-07-07 11:13:54: oggm.workflow: Execute entity tasks [fixed_geometry_mass_balance] on 2 glaciers\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x7fd64b33c4c0>,\n",
+       " <matplotlib.lines.Line2D at 0x7fd64b33c5b0>]"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
     {
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYYAAAD4CAYAAADo30HgAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAACHOklEQVR4nO39ebwkWV3njb9PRkRG5H73W2tXVXdX7wtNt9CsLg3SigqOMIM6guIzOAw+o/PMDCM//T064w9HdGZ0UFxQZkDHEXAFQXTYBGTppoHeu6uruqq7lltVt+6ae2Zkxvn9cU5ERm53v1W3qs7n9bqvzBsZa2bE+ZzPdxVSSgwMDAwMDEIkLvUJGBgYGBjsLBhiMDAwMDDogiEGAwMDA4MuGGIwMDAwMOiCIQYDAwMDgy7Yl/oENouJiQl58ODBS30aBgYGBpcVvvGNb8xJKScHfXbZE8PBgwd56KGHLvVpGBgYGFxWEEI8P+wzY0oyMDAwMOiCIQYDAwMDgy4YYjAwMDAw6IIhBgMDAwODLhhiMDAwMDDogiEGAwMDA4MuGGIwMDAwMOiCIYadiNPfgJlvXeqzMDAwuEpx2Se4XZH4+3eBk4I3f+xSn4mBgcFVCEMMOxGNEpgGSgYGBpcIhhh2IpoVSJifxsDA4NJg0z4GIYQnhHhQCPGIEOIJIcR/1MvHhBCfFkIc1a+jsW3eJYQ4JoQ4IoR4TWz53UKIx/Rn7xVCiM2e32UJvwrt5qU+CwMDg6sUW+F8bgDfJaW8E3gBcL8Q4l7g54DPSikPA5/V/yOEuAV4E3ArcD/wO0IIS+/rd4G3AYf13/1bcH6XH5pVaNUv9VkYGBhcpdg0MUiFsv7X0X8SeB3wIb38Q8Dr9fvXAR+WUjaklCeAY8CLhBC7gbyU8qtSSgn8UWybywulc/D+74DizPq3lVIphlZjy0/LwMDAYC3YknBVIYQlhHgYmAU+LaV8AJiWUp4F0K9TevW9wKnY5qf1sr36fe/yQcd7mxDiISHEQxcuXNiKS9hanHtchZvOPrX+bf0aII1iMDAwuGTYEmKQUrallC8A9qFm/7etsPogv4FcYfmg471fSnmPlPKeycmBfSYuLRpF9dr217+tX1WvRjEYGBhcImxpgpuUcgn4B5Rv4Lw2D6FfZ/Vqp4H9sc32ATN6+b4Byy8/NErqdSMO5GZFvbbqJmTVwMDgkmAropImhRAj+n0KeBXwNPBx4C16tbcAYbbWx4E3CSFcIcQhlJP5QW1uKgkh7tXRSG+ObXN5oaldLhshhlAxyACC1vq3b7fgqU8YUjEwMNgwtkIx7AY+L4R4FPg6ysfwCeBXgVcLIY4Cr9b/I6V8Avgo8CTwd8A7pJRtva+3A3+Ickg/C3xqC87v4mNTiqHaeb8RP8OJL8BHfhTOPrz+bQ0MDAzYggQ3KeWjwF0Dls8D9w3Z5t3AuwcsfwhYyT9xeWAzxOBXOu9bDXBz69xeE0ttaf3HNjAwMMAU0dseRMSwAedzM04MG1AMIRmF5qydjmOfVaG9vonCMjDYKTDEsB1Yj2JolLoJpNmjGNaLdqt/PzsZZx/Wob1PXuozMTAw0DDEsB0IiWEtA/vvfzt86b92/vfjPoaNEEOz+xx2OkKlcP7xS3seOwFLp+BT/6FD7gYGlwiGGLYDazUltRqw8CwsPtdZtlnnc6CPebmYkkIiPGeIgWc/Cw/8Hsw9c6nPxOAqhyGG7cBaw1VL59RrfHbf63xeL0IyulxMSX5NvZ5/4tKex05A+HuXz13a8zC46mGIYTsQZT6vQgzl8+q1vtxZtlnFEBJD4zJRDOE1nn/M5F6ExFAyxGBwaWGIYTuwVufzQMWwRT6G5uXiY9DXW1+G5dMrr3ulox0Sw9lLex4GVz0MMWw1pOzM1teqGEKFAZsPVw0us6gkvw5C34ZXuwO6pe8XoxgMLjEMMWw1Wo2OA3hVxaBnhn2KQXT2tV5EUUmXiSnJr8Lkzer91e6ANorBYIfAEMNWIz7IrxaVVAp9DHHFUAWvoN5vxsdwuSiGVh0yEzB6SPkZrmYYH4PBDoEhhq1G3La/2ow/jD5pNzrr+hVIj61t+0GIiOEy8jE4adh1m1EMhhgMdggMMWw11qUYYgNAaPppViEVEsMm8hguG1NSDRwPpm+HheOXj9LZDrRjPoaLHaHVrMKZb1zcYxrsWBhi2Gp0EcMaopLslN5Oh6z61U0qhjAq6TIZYP16RzEg4fxVXBoj/L0DH6oLF/fYj30U/vBVRq0YAIYYth7hTN1KrkwMbR+qczBxvd5OE0qzonwMItFxRq4HUa2ky0UxVMH2YPpW9f/V7GeI/94X2wFdW1I9QDbSjtbgioMhhq1GOMCnx1c2JZV1Q7uJG9Rr6IAObe62t7nqqn4VgvbK6+4EtOrgpGDkALj5qzsDOq4QL/bMPbxvVivHUS/Cb94OJ760/edkcMlgiGGrEeYkpMdXnvGHD35IDJFiqEIyA7a7MVNSMKRS606ElB0iFALye69uU0arAbnd6v3FVgwhMVw4svJ6C8/C0km48PT2n5PBJYMhhq1GpBjGVjYlhRFJE4f1dkU9UFZ4ZrFNXdqbC1eFnW9OConP8dRraqS7PMjVhnYTRq5R7y82QYa/xWqKoTjTvb7BFQlDDFuNZln5B7yRlU1JgxRDqwEy4Gun6iz71uacz7DzFUNYDsNJq1dv5OruPBd27EuNDlYMz38VHv2z7Tn2WhVDRAymsdKVDEMMW41GCZI5ZQpaSTGUzgECxq5V/9eXo4Fyue3QxNm8YtjpPRnCyqp2XDEsXaqzufRoNdR3kds9WDE88Hvw2f+4fccGqMxCbVG9P/sI/Mo+mH+2s15IDBtpW2tw2cAQw1ajUVKzPivZqX0zCOVzkJlU/gQrqbbTM/zllkOD5OYS3GDnK4aQ+IxiUGg31L2Q2zW49HajtH1kHx/oL2hz0lOfUImSM9/qfBYqGaMYrmgYYthqNErgZsFyVlEM59UAACoap1HsKIZWksZGfQyB3ympsdN9DJEpKaYYmqWrt4NZq6mU5jDF0Cip33Q7kt9ampQA5rQ56fg/qNel5zvrFc901je4YmGIYasRKYZVTEnlczFiyHUphsWWTR1n4z6GMHN6p2c/+wMUA1y9Dui4YiidgyDo/rxRUtVzt2NQbjdg9KAyZV04on6DMBN6MU4MRjFcDdg0MQgh9gshPi+EeEoI8YQQ4mf08jEhxKeFEEf162hsm3cJIY4JIY4IIV4TW363EOIx/dl7hRBis+d30RERg7O68zk7rd57eRUfrmfQFelRlxv1MbSU8xIuI8Wgs79TI+r1avUztBodxSDbKgEyjiikeRt+17avSGH8sCKG576szsFyO4pBShOVdJVgKxRDC/i3UsqbgXuBdwghbgF+DvislPIw8Fn9P/qzNwG3AvcDvyOEsPS+fhd4G3BY/92/Bed3cdEsQzK7cuZz0IbKhU7MupvXikENlDXpUpObUQyXCTGExBeWBQlNYBeLGIpn4cmPX5xjrQURMWgl2RuZFBZG3A4/Q3jsyRuUKen4Pygld/jVHcXQKHZazxrFcEVj08QgpTwrpfymfl8CngL2Aq8DPqRX+xDwev3+dcCHpZQNKeUJ4BjwIiHEbiAvpfyqlFICfxTb5vJBo6QGeiup7P2hOSBow1/8Czj1oCIFGUBOK4bIx6AeuioutcDeeIJbOPPe6c7nXsUQmpIulgP6W38MH31zJzrqUqPdUDP0bEgMMT+DlNusGJrq2JM3wdIpeObvaO69l0/P5pDLp9X9G6oFMIrhCseW+hiEEAeBu4AHgGkp5VlQ5AFM6dX2Aqdim53Wy/bq973LBx3nbUKIh4QQD124cGErL2HziJuSoJOJXD6vCpX92U90skazcR9DMVIMihgc5EajkiwXnMzlE64adz7D6orh3OPw0P/c/PGbZUBCZW7VVbcd7ZaaLAxTDH5VfQ7b4ztqNcBO6rwaCUvP84R3F58/n0YEviKFiBiEUQxXOLaMGIQQWeAvgJ+VUhZXWnXAMrnC8v6FUr5fSnmPlPKeycnJ9Z/sdiGc1blZ9YBDrHaRHgSLp+Hj/1q9DwcAT5uS/I4pqbGZPAbLUWGwO92UFBFDj/N5NcXw8J/Ap/7DFhxff7+VIZMLKfsdwNuFsHyKlez4nrrKssdIflsUg1YrkzdGi77YupVTUj9fS893iKGwb+VQbIPLHltCDEIIB0UKfyKl/Eu9+Lw2D6FfddU4TgP7Y5vvA2b08n0Dll8+aFYA2cljgI4DOpz977mr48yLRyXVi5Hpp4q7coJbcWb4g9luKmJws5fWlHTya3DygZXXGZTgBqsrhlZdDWSbHbTD77c6P/jzv3wb/NVPbe4Yaz4XfX/Ynpq5pycG9+uAbfIxNNVxx64DYUF6nL+fm+gQw+LzHQUzetAohiscWxGVJIAPAE9JKf9b7KOPA2/R798CfCy2/E1CCFcIcQjlZH5Qm5tKQoh79T7fHNtme/HIR9RAtlmED2zclBQ+8C09CL7y38O+b4OEDRltXXPzXVEodZJaMQwwJTXK8Fv3wDc/1P8ZqHBGK6kUw6UMV/30L8In/5+V12n1KAYnpWatqymGcKa/2cEp3H6YKWn+mMr+vRiIiEFPKMKQ1RCNmAjfDsIPQ2XtJOy+k9bh+zkyW2FGTiARWjGcUYTl5o2P4QqHvQX7eBnwY8BjQoiH9bL/D/CrwEeFED8JnATeCCClfEII8VHgSVRE0zuklGF96LcDHwRSwKf03/bjU+9UpSne9vnN7SckhmSuYxqITEl6EEpm4Ic/DOcf7wwCbk69ls7TsjwkCRrSUbbdoA0Jq3OMuWeUk3o57o6Jod1UpJPMXVpTUrMCs0+q12Rm8Dp+Tc1OQxKFtZXFCAd0vwbJ9MbPMVQsw0xJflX5hi4GIlOSNkGmRjulKWD7TUmtZufYP/4JHj5VpP3AN2njUEpOkl98Xp1Pfo+u/GsUw5WMTRODlPIfGewfALhvyDbvBt49YPlDwG2bPad1ob6sBqKZb8LCCRg7tPF9NWOKIZxQRaak0GySgswEXPsdne3CMM3SWfyEitBpEFMc8cEvLHLWGOLGaftq5udmhw94FwOhs/Tso3DgJUPW0b0Y4ukq3sjqCW69KmyjCPfTmy8QollV94Zf7zjItwvaNPg3T87xPXcE2KnR7oJ2cWKIK8GZb6nCeq95d/f3uF60m52JSjLDwzOKEJN2gnlnD/ml59VxC3t1rxCjGK5kmMznpZOd90/85fD11oJBpqRexTBogAkVQ/k8zYT6vEMMPTOzMKJp0OAZBDopybn0pqRwNr5SH2G/2glVDeEVVjclRYphs6akUDEM8TGEMfsXQzVoxfCJJxZ49MyyUgxx5RRXCc0YSTz1N/C1920+5LYdUwzAw6eW2DuSYt9IivPWtPYxzBjFcJXAEENIDN4IPL5VxJCNOZ/D2W1PMlccbl69ls7REKFi0Nv3zszCWWR9gGIIQ2MtRyXZXUrncziorkgMtf7vY12mpOpGz05vv0pUkg4f3ggxSCl55vw6nMT6d27g8PiZZfU91BY7dZHCe0skugk/NDdtlhjCcFWNR08vc+f+ArmUw4yYVqRQnYfcHqMYrgIYYgizOl/8U8ruv1o9+pUQPrCDopKiCBy3f7tQMTSK1IX6vCE3oBhCdZJw1D4vpY8hvN6Zbw5fp1UboBhG1q4Ytsr5PMiUFAQdRbEBYvjmyUW++ze+yFNnV4rcjp+LGmibETGMqt8z/B5D02Fmqvt3Db+rzZjVpOyEqwILlSYnF6rcsW+EQsrhZBALCQ8Vw0b6kRtcNjDEsHRSza7veSsgNqcaIsWQ78y+wsE6KjGdotJoceRcbDbp5aO3NXpNSbEH0K/B4nPq/UBiCBVDspPHsB2VOFdDu6Wu282r8x1qqqn1m9bWpBgane03g9YKiiE+0G6gm9psUZ3jhdIaB1A90DalzWNnirGcDq0IGiWksCkm8t2KIfyuNvNdhPeNvmcfOa32eee+EfKezYnWeGfduCnpUtxbBhcFhhiWTqp2irldcPDl8PhfrO2GXzjRMTWECGd1XYqhhxhsj9/63DFe975/pNkKOutr1HBxLNEhhvjMbO4oKk+iMNj5HBGDrchOBpem3EM4qB54qXodphr8WidUNYQ3osxkK+UoxKOSNoPIlDSAuOK/7QYUQ7XZ1q9rLCGunc9NHI6eL9FM6oCEiBjKVESa50qi28cQKobNmNV6IqIeObWEEHD7vgKFlMMzjQHEAKZZzxUMQwxLz8PIAfX+1h+E+aMqfn0lBAH8/ivhq+/rXt4sQ8LBFw5/+6Q2T0SmpI5i+PKxOep+wMySHtjcjmKoyCRjmeRgxRCaufbdM8T53KMYwnO62AgH7GteAgg4sxIxDPAxIKGxQmRSlMewRYrBr/STvB/zz2xAMdSaTb478XUq9TUSQ7tjSmoFklM1PfiGiqBRoibSFANv630MYbKknsw8cmqJw1NZsq5NPuVwrJ5FhhOd/J5OQqJxQF+xuLqJQcqOYoBOm83Vwjyr82rGvnC8e7muk/Sloxf4rS9op3Y8tFJYFH14YkYNeqcW9WCUsFRtI6AcuIxlXBoydD7HHr65Iyruf+8L1Qyxt6x3r48BLg0xhE7v7JQqyjbMAd2q9zuf19KTYcuikupKWUG/n6FLMcyyXoye/xrvT/4G6QvfWn1liO4ToWfjTy/r3JWYKakiUhQDFxkPKohMSZtRDPq+sZMEgeRbp5a4c98IAIWUgx8IZGG/yo1xcx3FYBzQVyyubmKoL6kBPiSGcJBYLZonNC30tl/UxHD8QoVmmCISD1d1UnzjuUUCbak6uRB7mLWfoRQkGc8kO9t3KYanFXlltDOwNzIp7HwWRiXBpQlZjWogpRSJzXxzsHluULhqWBZjJQd05GPYbFRSTdX9gf7s53DfCXtwm81VIGoLAMh4ktpK0Nc0PabMN4/N60cz/B4aRcrSoyxTyNCXFQQdAt2Uj6FjSnpmtsRS1efF1yrzUSGllGszfwBGdCUboxiueFzdxBCGqo5qU1JkflkjMfSaGBplRQxzcWKIJbjZLg+cWMBOCBxLcGoh9jDrGX6p3WtKij18F46oImeh6anX3BKSUJjHAJfWlORkFDFULsDyqcHr9Tqf19KTYSuikoK2Mr2FxNBbLym8Bwr7VRvW9UITclBfY8iqHpydpMftewt8Y1YTaUwxlGSKCjFTUrPUqbi6FaYk2+WB44rQXnxIdQHMe+o+nLn3l+AHf0+vFxKDUQxXKq5uYghDVSPFsFZi0KaFPmIogpvjxIUKvuxRDK0G2CkeODHPHfsK7BtNd0xJEA32yy1nsI+h1YT5Z5VpJho8e4gh7mOITEmXIJch3mdhz13q/czDA9Yb4nyG4YohHNDD7TeKkFQKehbcaz7U17Dg7YPKrDruOiA0Icu1EoMenG3X47a9BR6ebSGF1SGGZpnlwKNMCuHraLO4GtkSxZDkgRPz7Cl47BtVSi5UDHPufth9J/ok9TkbxXCl4uomhlAxrJsYNCHUFrpnTdqUdGKugt9nSqoR2C6PnV7mxdeOs280xem4KSlUDEGS0XQyluCmH76FZ1VW8+RNnfDWPlOSHjATMcWwQiXO933+GI/q0MQtRbyc9vj16v3iicHr2T2KYbUKq/HBaDMDU+ifWMWU9I8LeTUrH1aBdQgSviKGRLPn+z//RMfkF0ekGFLctjeP34a2OxJ9D7JRYqntUZEeIow2i5PnFigGaSV58MQCL752nLCrbj6l7uNiLebPCjOkTentKxaGGNxCpxXmWs0vcWdkPJSxcgHfHeVcsd5PDK06VZmkFUhefGiM/WPpgT6GKi5Zz0ZaPbOyMLFt8sbhiqHdk/kMQ0mu7rf59b8/wl9+88zK17oRhBE9Tkqda2qsk38RIgjUYBhTDG/5Hw/yuw/oAXiYYujN69gowu81M6EGul7FoJ3Pj1d1qOY6I5OskBj82L1UOg+/93J44q8GnI8mBleZkgCqVq7HlKQUgzq/cjd5bkG46kw5YK7c5EXajAQdxbCsiaHSaPHOj+noOKMYrlhc5cTwfEctgJq9isTqD1mcDMIBo9WE4gyLSdXHuZOH0FEMRd/CSgjuOTjG/tE0i1WfckPPHrViqEqXrGv1R35cOAIImDgc8zH0KoaYj8ENiWEwyYWJV/OVbZj1xZ3PoAoTLvQohlb3OqW6zxePXuArJ2vK4bsWxbAVxBAWNexVBPoeeLatHf3hb378C/CV31p191ZLbW/5McVQmVXqY5B6ajXwsUi5DteMpcl7Nksyowiy3UL4VcoyRUVqhdUobaFiUPfCk7NqHy+OEUPoYwiJ4fiFCscW9D1riOGKxVVODCe7iUGItdUYKp1XoXvQIYblU4DkjO5g6vc5n+ssNC1u25Mn69pcM6ZmyqdC1aAH+xouGdfuj/xYOK7MHuEsHAb4GMKopOSqUUnni2q/c2vNzF0PIh+DVgOjB/sVQyyvA+CxM8tICTPL9ZUrrMYHwFUGpvlyg3/yO1/u5IsM2o/jKWLoNSXpe+B5qbuphcTwj/8NPvvLqzYJSrbU92634qGlmsgHqY92k6a0SSdthBBcO5llMUgrxaDJvUyKqs6M71MMm8np0BOKR8/Wmcy5HJrolEnPedqUVFf38Zml2uAcG4MrClcvMYQ5DGFEUggnvQZT0nnYfUfnPUT+iuO+mm2NZDwCEtFDFzRrzNdFFAa4f0wNiCd7iKGKR8a1o3j26OErn+/u+AYDfAxhHoOtVIPlDr2Wc8U614kzVMtrCKcsz6ry2WtFOOgmY8SwfKrbth53UAOPnFJEcHa5jkyNrNGUtLKye+Z8mW+eXFK1h4btx/ZU85kBzudACk5J3UypdE6pwpMPKNNLMWaCW3wevvRfu0Jyk211bskuYtDnMSCTOmg1aOKQclT+wkjaYVFmdEi1Uh0lUpRDYmiUO2Ymy92k81ndNw/P1HjxobHIvwBgWwmyrh0phpkuYjCK4UrF1UsM1QU1aMYVA+gaQ2uISpq+VSWbhe0OdbvOJ2qj7B1JMZZJ0hJ2NAC1/RpV6XDdpJqN7R/tVQxxU5KNl7TxRayLW3m20ws4YSkiGepjCBsAZYebkpZKfDz5C7y+9JGVrxVUN7bffwV88PvguX9cff2oYKA2JY0eUmqmeHroOo+cWgJUKYl2srBGU9LKA1OzrWb1lUFlKaL+GJ7KC+lJcJPNCjVUEEA1kVWD+ZlvdLZbeLaz8rf+GD77n7p8T8lAE0M7di81hiuGdrNOA4d0UhFD3nOYb2fU4K+JoSJTVGTMx1BbUr91emx182ezCn/2E91l5qPvQvsYKkGXGSlEIeVQrKnvcMYohqsCVy8xLPWEqoZIZvrLI8Th11T+QG6XGqhLMcUgLL61lObQRIZ00qKFEw3W0q9TJ0nWVQ/VSNoh69qcXtQDjRczJSVtXDuBL5LdiiE71TkPNz/AxxBzPkfXMpjkxLnHyIgGN7aP0Gqv0ju5OqccyHPPwAdfC0dWaazXrKgBy9LmtNGD6jVuTurxMTxyeikaFOt2bm2KYRXzSViLqjyoLEXclJWZ6KuXFDSrVFGqbV6MqsE8TorxrPeoFHqHqD1NDOFr1+cDFEO7WdOmJPUdFFIOc62UbiSltivHFUNoSvJGlMpdTTHMPqn6jTz7uf7P2mGdJjtStHHkU05HMSzXBmflG1xRuIqJIQxV7TElJYfPsoHOQ52dhtx0RzEsPo8s7OPYXI1DExlSjoUv7C7nc10mybjqwRdCdEcm7fs25kfu4KScIusqYmiS1I3vfeUcDRUDKD/D0DyGkBhyQ8NVM/PKNHSbeI7F1RzQfk2Fyf5rXd5hNbNSbw2kkBjiDuiYjX+2WOfscp3vvFERX0VkVlAMsZn+KoNhRAyNATkIkfPZhfR4X72kVr1CTbrYCcFMK48sz8JzX4KpW9Wx52OKYe4Z9Rr7PVKy2vWqPtdEXj7flwne9rUpKanItJBymG1pU5w2W5VkimoYldTQiiE10k8Mc8fgD1/dnecQ+lCKZwd8F4psZSLJdZPZvo/znh2Fq55ZqhvFcBXgKiaGUDHs716eTK9sSgrNBdldkNvd5WPwc/sp1VscmsiQcW3lgNbEIFqhYuh0U90/muqYkqZu5hMv+mMqpMi4Fq5t0USbkkL7d1wxeINMSbFaSdApvT0AU8UnAMiLKstnjw6/XlDfh5NS+/MKq8f0+9XuxLX8HqUg4oohluvwyGl1Hfffpnwoy2RWVwzeyOrE0FaEUGkMMiXFo5J05FHMnBQ0KlTxuGl3jrNBgWDxJJx6EA69UpnGQpJrtzokEfs90rKuX2vIkARCsms3uwdtIPDrNOOmpJStnM8Q3atlUngZHXjQ1D4Gb0T9NnFT0plvwOkHYfapzrLw2koDiEHfN2OFHFaivz1oIeVEzueZpVosq98Qw5WKq5cYbv4BeOMHOxE+IVbzMUSKYUqbkjo+hmVvDwCHJjOkkhZN2SGGRLtOg6SKONLYP5bm9GJn4AhDVzOujesktI+h3q1SQgxSDNqU9BufP0Gj1da9pwcrhgONI5xH2ZP9048Mv15QA3DoSE6PD++RHF8/TgwJS5nsBhJDikdOLWElBN950xRWQrDQTqtrG1RfKRzQU6OrmjI6imGQKaknKgm6HNDKx+By+94RZuUoVnlGqZVDr1D1qkIfw+KJjlLTA387kGRQ+89SpRGWV4+b/nrMScr5bJOKmZKW0LP3JVVOpCI9CiM656ahTUmpEU0Mse8iTKqL59uE1zaIGDTZTo3k+z+jY0pqtNpcKCllE9/O4MrD1UsMY4dUme1eJLMrO/JCx2F2WimG6rwyEZTPc16oGf11E1nSjtVRDEGAFTRp4PQphprfZq6syKPcaGEnBK6dwLUTqotbqxFTKTFiWMH5/D+/dkZF+cR9IDHIepFr2qf5ev678aWFdX41Yqh0Bvr0gJj/vvUHlLoYPdgdvx+ZhFI8cnqJG6dzZF2bqZzLBT+lsrwHqZ1wMEqNrqoYGisRQ6w/RqQYYn4G2axQlS537iswK0f0UqFKiY9fqxRDEHR3/NO/R7VeJyWatEmQpUY1PH789+p1QPsN5Xx2Os7nJamJQdeZKosUE/k0dZJq8K8tqe+hVzGEk4F4pFVlJcWgvtNdY4OJQTmffc4tq++sjUULazAxXzgCf/ojm698a3BJcfUSwzCsYH4B1CAtEmqWmdMD9ZmHADjRnsCxBHtHU6STFnVpq8FaP3h12W1KumZcDZ6hn6HSaKlQVSFwbUvZcldQDK3aMj/74W8RhOVa9czVx6ZU96GwVw0EPXV+aie/SUJI6ntexFG5j9T84yt/J/GBPj0+vCNbtH6lv2rq6KGBikE6Ho+cWuLO/SMA7C54nG1qB+sgc1JIBqmRtfsYBjmf48SQ1g7XuBJqVqmR5JqxNGVHR+rsuk1FAI1dq37T0owqhR5CD/z1snpdToxgCUm1ogfqelE58aFPMchWg4Z0SMd8DMvofAKtGEQyR95zlJ+hEXc+p7q/izB3JU4MIZkP8DE0G+r+3DM+RDF4DpVmm+fnddJeQnQHRsTx/JfhyCf781a2E77pJrfV2BJiEEL8DyHErBDi8diyMSHEp4UQR/XraOyzdwkhjgkhjgghXhNbfrcQ4jH92XtFPKD6YsFZzcdwXs0wE5ZSDKBsz8BTtREOjGewEoK0a9MIrK6+vXWcblOSDlk9rYvplRutiDhcO0E9Ugwx81UIL49oFPnrh89EESOh2aqFrWzC+T1q5t0zO62e+DoA6YMv4ikOMlZ8auUHK04MmfE1KoZeYjioBs7qQmcd4GQJivUWL9ivTHq7R1Kcrvc0qYkjrhhWMSWFimFguGpvVBJ0DaSiVaOGSypp4Y4qEyEHX6lex65Tr/PPwoVnILdH5RKExFDRxGArJVILc0UaRZi4Qb3vVQztblNSPuWwHCqGpZM0hUfKc8l5topMahTV8QY5nxuDTEma9KpzfTWOSpUKDWmzfyzDIBR0vaSwHe3+0ZT2fw34/sNnZ6V+GlsJKeG/3wFfeM/FOd5Vgq1SDB8E7u9Z9nPAZ6WUh4HP6v8RQtwCvAm4VW/zO0II3ZWE3wXeBhzWf7373H4ks2qA7W2CEyIeNhrO4E89AMA3ioUoazTtWDSxCfxG9AC1hEvS7nzl+3pyGSpxYnBCYqirB9wb6ZTJANrJPBYBaRqdgU8nkPlYKu48rwvExZOxAGa+yWk5wdjUHp5zrifjLw6vBSSleth7fQwrEkl1sCkJOjNJPZA9dk4NUpFiyHucrOjboTeBDzqDkTeijrPCeazoY2jVlfJL6DaotteV/Sz8KlXpkU7aOFM3qXLXN71WfRg2dFo4rhTD5A1dPp9mRZ131VPE0NBEQX1ZkbWT6VMMot3scj53KYZWjVoipTqqeTalwEMuz3S+h15TUnOAYoi/7+kvUa5UaeKwf6znN9PI63pJT51T13VoItOJmOtBs6aPPaj17Hag3VTf5Zff25+9brBhbAkxSCm/CCz0LH4d8CH9/kPA62PLPyylbEgpTwDHgBcJIXYDeSnlV6Xyxv5RbJuLh9UqrJbPdwghzEQ+/RDSSvKNhSQ3TqtEtVTSwpc2QavRXztII5W02JX3ODarHqZKox2Fs7q2RS2uGOJmJOBUVRFIngo13V+YdpO2sAChwgsLe9Xy5dNd26YuPMojwbVM5z3Opm9UC88O8TO0GoCMzn3Gz6iHcYWqrV3O6hBjh9RrDzE8V1Tnfu2Emh3vHkmx0IrF6g88H9RMWQbDCZxOgttQU5KdUmVQhOjznVjtGlVc0kmLXfsOcmv9AyxOfpv6ML9XKYT5Y6oP94QubKgVjl9TROCn1f3hV/UgWS+qaLLcdB8RK2KwY1FJDj42vqW+96pIk3Ftcp5DBQ8Z9rcIfQzxQToclHtNSWmtjHoVZE31D7lmCDGEhfSeOltiIutSSDnazNlvSjp+RhHe/Nz6u95tCOGz5VfgK++9OMe8CrCdPoZpKeVZAP0a2kH2AvGuLaf1sr36fe/yPggh3iaEeEgI8dCFC6u04VwFdb/NO//8ET70lefUgnBAG0oMsQzkzKSadTaKNLN7aQWCG3cpYsi4tlIMrWbnoe1tSoNquP6oDtcsax8DKFNSLbCVLbs8y7I1xvu/2Imdf0RPjnKiFjWeJ/BpC/UQK1OS/vriiqEyR6Z6mkeD65jOuywXbiJAwLkhuQlR6YoMS9Umv/kVzf8rmZOaAzqzhfkioQO6VYOEw3wtIOfakZLaU/DU7BwGk0+rpkJfQ0WyQpJbqBgGhqv2NglKj3XMXKgieKEp6bqpLCA4dkETVSKhiO65f1Tk1aMY/JoamANtavSrHcUg3YIKde5RDIl2g4ZMRqaknGsjBNQsZfevkCLn2eQ8W5XeDp3IkSkppp5CH0NoSpJSzaZ33a7+L850HbtWq+HjMJp2Bn6PITEcmy2xd8QjlbRoSHsgMQT62PW1lFrZCoTn4KThwT+A8ubGAwOFS+F8HuQ3kCss718o5fullPdIKe+ZnJzc8Ik0WwE//b+/yUcfOs0vfvwJPvbwmf5y1X5NRVmcf0JFofSWpsgovlvSVVVv0sSQTipTkmw1I3u2GEAMd+4rcHyuwnLN7zIleY5FHQepnc/Haml+5W+f5sETavB6cEYNdnkqHWJo+wQirJ/fUoNVMgvLMWKYUUlqR53DpJM2uXyBU2LPcMUQq2k0X2lyIdB1mlYihkGmJDeriDSuGJw0i5UmY9lktNqugmpfCQwhhoYy+4TEs4IDemVTUqO7F0R6rHNNbR9LtqhKpRgOT6l74pnzsfMZuw7OPqzeR4pBEUC7ptazCnv0/0V1D7QbvPfL5znPSD8xBE1awiZpqUcykRDkXFuV3kYlt2WSoWJIIaT+zb2R/oKLvaakZkURaEgMPYqhWa8RWEmGufRCU5LfluwZSeHa6t4c6HzWz02repF8DOHE4MX/EtmqU//Cb1yc417h2E5iOK/NQ+jXUFueBuJZZfuAGb1834Dl24JWO+BnPvwtPvPULL/4/bfw4kNj/Ps/e5RnFnXMefhwzR1VURaf/xWVUBT43WYdbU6aYZKkleCg9jGkdLiqbDejm9fqnUUDd+im64+fWY6ikoBOuKqvFMM8ar13/+1TnF6s8sSCeohzokrND30MPi1i1TCFUKohXqNo5lsECOZytwAwkXV5rH0AGQ5yvQizgZMZlms+i3ItxDDA+QzdkUl6xr5Q9RlNd4hhz0iq03NgIDHUla9lDcTQaKnBs9xodZLMov30NAlKx5zqenCr4eLZFntHlH0/dL4CHdMYdLrqaWII23m6Y/v1/8XIvHOhleJkM9cXRmwFzb7BuZB2KAlFSiWZIqsVQ1nGzjtUDPHvIvzemmX1+4XRVhM3KLVV6n6smo06wkoyDKFiANhdSJFKWtSDwc7nhO7F0V6pZ/dWIiSnXbdxet/3IR/8A0qli0RKVzC2kxg+DrxFv38L8LHY8jcJIVwhxCGUk/lBbW4qCSHu1dFIb45ts+V472eP8qnHz/H/ft8t/MTLDvH7P3Y3+8ZS/Nrn9SAazpTDDNWnP6lC8aA7OkgTw7HmONdNZXH0jC+d1JnPrY7z2XL7bbh37FPROA+fWuqLSmrgQF2VXT4fFEhaCR45tcTP/cVjlPTgmacaUwxq1gmdMsnk9yCXZ/jNzzzDbLEO5x7lnLWbXEEFiY1nkjzaPoBYPj1YhscUw3LNZx5NDMMcfUG7qwHPXLnBD7//a2q2PXqwkyWsyWOx0mQs0xmUJrIuzcQqPgbbW1ND+lAxBBLqfk89KL/eTV5xYtADbMvySCQEQghumM52E8O4jkxKjaqopgHEkJmIEYN2pJdkipONnMpDiJkrLekTJLoH50LKoaiT3JYDVVwx59lUiJ136HyGzm/VKKsCj6BUQxhenJlU92tMMUgpafn1TjXfAQh7MgDsGfHwbIuatJEDFENC96HoikqqzMP/uL+7jMhWISrG6HHEu4OUaFKcW19TJYN+bFW46p8CXwVuFEKcFkL8JPCrwKuFEEeBV+v/kVI+AXwUeBL4O+AdUoa6mLcDf4hySD8LrFKtbeN468sP8V/eeCdvfbma+Y2kk/zS99/Khbp+oMKHthbanaWqoAkdp3Ps/aPlQmRGAki7YeazH5mSBhHDSDrJwfE0j55eotKMOZ8diwZJhA5BPdcu8MobJrlpV45/PDZHdkTF3udFjBiCVtQHIqyGSWEv7aXT/OZnjvL7XzwO55/kGXkN03k1sE5kXb4WKPXA8c/3f1Gx3grFtSiGeFtP4CNfP8VXj8/z/i8eh713K3/H4vNqv3aKhUqzSzFYCcFUPk09kR7cSyJsBxrNkocnIzZjxQFLjR4ndag8QqTH1WDWbkX7bFud3+vGXXmOnC91lEcYmTRxo1JmITFIGc3Y85O6QGOjHA2URTI8U9H7DQdoKbGlj7S6TY15z2ExUAp0qe1pYnA6hfRguGIIS71ULnRMSplJFWId8zHMV5pYgY/lDCcGz0lEJq69Iyk8J0GDJMEAtRY2KOpSe+cehZNfhcf+fOgxNoxY+fSllrqGWsUohs1iq6KSflhKuVtK6Ugp90kpPyClnJdS3ielPKxfF2Lrv1tKeZ2U8kYp5adiyx+SUt6mP/tp2af/tw4j6SRvuHtf17LpfMzxGc5WQ4fk4dfAvK4pFDclZRUxPF4diRzPoHwMPrYyPelZrTOAGECZk77+3KIqpdClGDo5D6dbOUbTDj//2psBuOeGg4BSDPGopBaKWDqKYR9WdRaHFn/3rePIheM86u+NiGE8m+QxeQjfG4ej/6f/5HqIoUyKlnCGl8WIKYwgkPzpg6pY4d88MkNp90vVZ899SX0nTorFapOxTLfTc3fB00lcg8JVQx+D/p1WyLANFQOoiK/u/dQ7ZcFBJ55JFVmkJwVBTFHctCvHUtVnNmxsFBLDpM5L8AoqWqtVRzTLNKRNOlfAl5bq+9xQg1VJpniqrO+D0M8QDm5Wv2KY1/WSQlNSXjufgY6vJW5Wk1KpkfD8Khc6v1VmXBFDTDGcWqiSpIWd7Pd/hRBCRL2f94woU1IDB+n3Kwanrcgi0YgNzuHk6thnhh5jw4gVVVxsqe+vUblIobJXMEzmcwzj2STV8KHrVQz3/X87K8ZNSdO30LbTHJe7uxWDo6KSRCzBbTgxFFjQFU47piRL+Rg0Tjay5FMOrzg8yW/98F381HfdgrSS3Yqh7ePLnubthb0IJNNikbHqCQSSJ9v7mc6p2dVE1kWSYHb6FerB7cmS7vgY0jqRTlBOrFBIL0YkXzo2x+nFGm//jutotAL+7GRWhUye+CL4NQLbo9psM5rpHhB3j6QoSW+IKUnP9MNBfYWopEYXMfQ4oFv1/qgkUNelr0Hand/rBh2GHJmT8vvg4Cvghu9R/6dG1Gt9GeGXqZDCsS0qIq36PmvFUCLN+bDERjhAh8Xoesw5qvS2OoeyTMXCVfW1e3o/cWLwqyqMNySG8mzH7Jee0MTQyX4+tVgjKXyS7gCfUAyhA3rPSAovnpXfg7BBkdWMKYZwcnXmob7igZtGFJXksRASQ3UIMTz3j/Dkx7f2+FcoDDHEMJpOUhUhMegBrrqoInt23a4GAbfQiVwCuPkH+Mi3f4Zlsty0q1NSIKUVQyJoRpLbTQ0mhjC5CyCT7PExaJxs5iJb7/ffuYepQgrcvHI+NzvO52akGLTDVYes7mae2x3lPzki97Or0DElAZwYfZl6aE8/1H1yMdNQUecDFBP54WUxYjkb//uB5xnPJPk3r7qBF+wf4U8ePIk89Eo48SXwqzSFOvZYupsY9hQ8lgMPuaaopLUphlJvLoNf73c+gyKGUDHEcjFC0o+IIZGAH/8E3PS96v9Yu1XLL1MVnfwD2y93fAxkOrWXIsWgK/D2EEM+5TDbUvsp45FzbTwnQU3vOyKjuI8hNL9FimFWKQZbV8fN71aEq79bpRh8XG8VYvAcknaC8UwSL2nRlIOJwZXq90+2Yr9d6IiWARz/hxWPs27EfAxzTfXstGpDcmy+/N6OOdhgRRhiiMFKCNyUnvWHs9XagnIwArzut+HNf6VsyiGE4PG5gELKYTrfebAzbkgMPn5DkcwwYrh1T56w2nEmlvncQA2YUlgskovkfHRor8BootqVx9CUihjagVTLC8pctlvM89rpRWoyyfNymiltSgodv094dyuHZa85SUeZ4KRZrioVsizyqyqGpZbNZ56a5Q337CNpJ/jRF1/DsxcqnMi9UEXFXHiGhibhXsWwq+BRCjxatUGmJJ1/sKaopIARHZvfrxgGRCVBl2IQTqdExGgmyVTO5elzQwadkBhqS1h+JRq864k0dqujGKYmJymKrEpE7FEMwuk3JfUqBiEEQXhe4X0Z/y7C+zY9oQotVubUX2ZC3bdhGRddM+nUQpV0oo2dHO5jANVYak9BOeO9cNISlnmPwZXqWsKe1+o7WVB+EK+w9eakmI9htqHDaocRQ6M0vM+HQRcMMfQgl0nTxuqYkqoxYshMKAdqD46cK3HjrlxXqKFnqzwGS7bw6yExDK5Fk07akamiy5SkFUM7PUFAois6RB0kTyFRo+p3fAwNaUckE9VLAg4lF7kzeYajci8BicjHkLQTFFIOMw0X9r94ADF0FEBYk2lRFFbwMaj1P3+8QjuQvOnblAP2++7YQ96z+eNzOtHNr0TXN9ZrSiqokNX2QGLojUpaOY8h3HdfvaRWY4gpaSG6BtGTvX3jrlx3LkMcoVmnvozTqlAXattGIq36PjeKtEkwUhjlwHiOZWusz8eQ6AnxzXs2S7osRplUdG/IZK77mHFHvPbLvOuTx2mnJzqmpJD4QmLQ5qRTi1VSVltlcq+A//u7DvOLP3ArQORjEL1RSUFAGqUivHhL0+qCIqprvwOOfXZrC97FfAyzdfX9BMOy8pslpYqHHf/PfgIe/8utO7fLGIYYejCeddVsL+5jCAeNAZBScuRcqcu/ACpBSerww1Z1mZZMkEkNl+t36nyGTkmMRORj8HXNnXyqlxgKFES1U9a53aIZJJjU/oNirQVujmoiwwF7iczSM5xzlYlhKtcZCMazSeYqTTj8ahVBEq/AGctjCB3aizI3XDHo9f/uyDIvuXY8qh2VSlp87+27+YvnkpF5qyrVOYz2mJLGs0nKeMhBUUmtOscXW7zhAw+r/1cyJbWDyEzVb0rqUQypmI9B//aJXmKYVsTQDgYMLDFTktOuUtcRTU07o/o/14tUSDGW87h+KstsMDKAGPpNSY8Hhzg59lIeDq6PiEG4oWIYUa8hobTqkSnpubJFxR7tOJ/D0uK9xLBQwxOtPsd3L+4+MBp12PMcTQw9jXoC/b1Vpas614X+qtoCpEfh+lep484+Bae+Dr9xOzz9tysed1VEPoYUM5oYBt43oBRD0Bpc1cCvqdanJ7+2ufO5QmCIoQfj2aTq9RsRw2Jn0BiA04s1yo1WV0RSCGHrGX9tua97Wy/uumYE6AySypSktq+7araX83q2d/Pk6JTEkO0mDanqL0EnMmnemuQWTiAqs1xz8z38s3v2R/kWABMZl7lSAw5/t1pw7NOdY/hVVWjO6vT9nZNZHdo5oE6RNsM8V5T802/rjvo6NJGhWG/jX/NyAKqBup5exTCadqjIlHLa9qLVYK6R4IkLYcvUFcJVW0FkphrofI4TQzKtZt4xU5LldSu8G3blaLQCnp8fMLBExLCEG1TwLbWtb2VJtavI+hJFmWYi63L9VJbTrTyyx5Rk9WTGq0J6Wf7gml9nllGy+vdPuMMUQy3yHZRlilJIDKEpCTqh1qWztNoBM0s1kqIF9srEEEfKUYERCdmKCjcC1HQ00DkZNhPSii9U3dfdp/7/3C/Dh74flk/CucfWfNyBCCsXS5vllkMgxQrEoJcPMieF9cQGmMeuRhhi6MF4xqUi3Y5tvbqyYgidkb2KAYhmYbKuiCGzAjH8kxfu43/++LdFmdNezJRUSaqHut+UVCBHhZofEoPyMYRmotAncE6Oc0NL9Q246c57ec8b7ujazUQuyXylCdO3qhLSx7/Q+dCvqmqgEBHDhXaYy6CiTbqiivWDmkimuf/W3V3H2TOiZrZzk/cCUA6SCNGdWQsqlLhMSjlte+HXKLUs1awGVk1wG0k5CNFTFkPKKFy2C+lxdU1a9dhe928a/sYDzUmuDjyoL+MFNZpaMbScDClZpV1bpijTjGWSHJ7Ocj4YISgqYgh02Kc9QDEAnFlS32k4sbBCP1ifj6Ea+RjKpFgSI/2mJDerzrV4lrPLdVqBJCn9VU1JcXixSUu8vWe1rL6Xc1I/L2F13NqCmlwV9sLkzXDkb2HyRkXMm63CqhXDUlMVj6zgIYbVOQtNTIOyssMe8CsUZbyaYIihB2OZJKXAVcXAgkC3TxxODF9/bgHHEtwYi0gKIcKHrV7s697Wi6Sd4Dtv6oTBxp3PRUsdv9f5jFcgLTu1kmSriY8dRRyFiuFMMEYCHaEzdWvfscczLvPlhnJOjlyjIllC+J2CeGEI7GxbR2VpP8M/+d2v8EsfVz2kG7rs8stv3h8VhAuxd1Tt53j2LrW/tstIyunrMzyScihLD0u2+uvxtBqUWgkkCQIruUqtpDa31R4il0x0E0PbVxEyvdm+qVGtGCo0pYXndn9+eCqHEAx2QDva71FfxguqtG1Fpm0nR5oqrcoSRdKMZ5IcnsoxK0ew6gvQatJsqGuwk91EFRLmTA8xkB7njJju1D4KQ3f9WjTQlqXHhSCvBuVWraMYQIeszkTl3i3pr0sxeDr5Euj6fcLEsgVLk1CY/RyfXL38Z+EF/1xFdHkjW0AMqhjjckPd31XcqCxH93rNDokNUgwhMQSGGMAQQx8mskmqeLTqukOWDFZUDJ9+6jz3Xjs+cNAPo0wSzSJ1ubJi6EU8j2HJUjPDQT4GTzZo6A5csu3ToqMYijUfKSXP+XpmmR7vzsHQGM8mWaz6+O1A2a3jM6pmFZJpgkBS0oPr+ZY2sWg/w1Nni3zwK8/xN4/M8PQpZTf/nhde13ecvVoxHPfH4I0f5HPpV/dFJAHYVoKWrcmn15HYquvZIbQT3orEcEP7KG85/v/wcudItykp1la0C+lxqC3Qbqh+z+keYkslLQ6MpbtLY8ThFaC2SIYaLUedv0xmSNFEVhcoaVPSdZNZZtG/Sfk8jbomBncwMZxZqmElBJ6jHtdMOsP3yN+Cm76XJ2eK/LfPHEVable4aoUUZ9sxxRP6GCAqixF2DkwEzXUqho6ajSu2ujYlVVydANooKj9DfbkzubrzTfD696l+5F5+cM+NYZCSRz71h9HkQx2/0RUYUZYprNYAYojnxAxSDGEZc2NKAgwx9GEs41KRHkG93EnGGaIYnr1Q5viFCq+6eXrg52GZgUSzTGMVH0MvXDsRZWHPiXGEgGyy38cAYDXVwyV1Tf+IGOotqs02pwM9CE3d0h1qqxHmMixUml01f4CoCmqp3kJKVVspqrBamaPVDqj7AULAu/7yMR45rsot3HXt7t7DMJl1cSzBmcUa3PqDPNfI9+UwhJChgzVODEEbAp8lXw3YfsJdMSop1Vbfy7Rd6VYMsaSoLuh6Se16hSoeqd7vGxWZ9MipJephJFgc3kjk1A1DSqX+jezyDEVSjGdVae12mD1fOoffCBMg+0tigHKcZ5JWFPWW8+yoMOD7/uEY7/3cMWTY3rNZJkBQxeVUI+YjSccUQ34PFM9ycqGKmwgQg9TTCkg5utwLdCmGMOPYT6tr8yuL+l6SgydXbn5diuH5I9/kzgf+LU98/iOdhX4NbJelqhrQm4kUTnuA3yl+Hw1KslsKicEoBjDE0IfxbJIaroqwCDM2Q1tuDz77lJod33dz/ywcIKEfNtsvUV/FlNQL105wRO7nUzf9Kg+nX0LOtUn0mFzQTkgRzobaPi2pyiakHItizWeh0mRGamk/fdvAY4URSrPFxgBiqOjkNvXATOW9rnpJFW3G+vGXHiQhoFwu0RY2YoBpIpEQ7C6kItPIQqU5UDFAzMEan+np2WnotG4Kd2hUUhBIkoH6bNRpUo6XxIglRXVBl95uNytRye1evPHu/Zwt1vk3H3m4PzrJK0QlzqVOghT6OpxWmaLMMK5JODWmHfOlszQb6jyTPcSQtBOkHN2fIeZfynk2gVTf3z88rcx+bcuLnM9VUoDgRL1DDK3UGL/+908rk2FGNSU6uVDl4Ii+J1eJSuq6zCGmJL8eZoWrEOl6eTH2DA0ihty6FENlQZFuq7rUWdhqgN1RDC07M5gY4vfRQOezIYY4DDH0YDyTVI1QmpVOOYwhpqTPPDnLzbvzUYvOXoSKwW2VqJOMTAFrgW0lsBIJnhj9Lpbqst+MBBExWKGTtt3ExyKdtMmnVN/nhUqT54NpJAL23DXwWGGy22yprga3RlH5VyCqgho+eLvyLouEPob5yERzw3SO3/hnL2BPRvbF/8exdyQVOVMXKk3GhxFDSkf5xGd6ehAKB6UGyaFRSc12QAo1ixxJNHpMSZpM+ohBFdILakXqJAcSw6tumebnv/dmPvX4OX75E092O969AlJHt4RKIeF1fE8lUtH1ju1S+R1B8WykGNwBZSlCc1IYxgwdkvjU4+ciYm5ps5pslFQ5EeBopbO/J5dd3vf5Z/nEo2d1v+wa5+cXObQBYrASgnai3/nvaxOPM6rCkZvlpZWfIW99iqFZUj4t2YiZilpKMUR9z5MZ3GA1xbDU/3moGIyPATDE0IfxrEsVV9kpI1NSv2JYqDR56PkFXj1ELQA4OpvUCeq0Eu7QRijD4NoJGq02xbrfH5EEETHYrYoaoHR11VTSIu85FGstFqpNzjDJ06/7JNz+hoHHCTO2z4eKQQYqGQi0jyHTIYaCRwubtluIiGE38+StBvfdPM3rbx0l0dukJ4Y9I0oxSClZrA5XDE4YedPoVwyhfbs2pCwDKGJIC0UkeavR3d4z6qg3wMcAWKUzVHGj2Xov/q9XXMtPvvwQH/zKc/z1w7EmSF4Bob834SrytFIdYmhYOTy9z+ld+2jJBOW5U/jNUDH0E0MYcBBXm2HY8p9/43SUzNgQLvg12rUiZZliT8HjfLtz7GMVRRZPnS1G9/PywgUOjOj7ah3OZ4AgND3FFEO7rn6r9Liq7NqqLq2iGPIrt4jtQTskhvhkQCcqLtd89V24WbxgwD3RWEExtP1OjwqjGABDDH0YSTlU8bBbtc5NrWc7T58r8gdfPE6p7vO5p2cJpJpBDoMVs9u2E2u34YZQxBBQrLX6I5Ig8jGkZZVmO0C0fUUMjkU+5SjFUFaz5vQ1L1Ad5wZgIusiRKgYRtTC0Jyko5LCiKTQf9FyR6EyR33xDP/HfSe3H/ltvX6tv99zDHtHU5wv1lmq+vhtOdTH4KRDxRCbUUYx60nGMkkqQXKoKanZCkihBq2caHT7GMJteu3q+nd2ymeoSZf0AB9DiJ//3ps5MJ7mbx6JJQOGuQyApUNd7XRncA5VBMChyRyzjFBdmKHdVNflpfu/t1AxZLtMSer9w6eWuE/7t+paPfm1IhU8bt6dp0SKwHLB9jiqG1DFiYH6EtcU9D2xDudz1/oxYg7beo5NTFKVLu3ackwxDDDHeoV1mZICHewgmjFi0ImKS1VfqepkhjQ1gl4zX/w+6lUMxRk1GQJDDBqGGHqQSAhIpknQVo5EkVCF84Df/PRR3v23T/Gd/+UfeP8Xn2U673LbnsLQfTmx+jPt9T546MgkP6BY97tszJ0V1OCTo0at2UZIFZWUTlrkPWVKWtROuWEzcwDHUsXRIsUAPcSQjpmSFDH4rrLHT3/tP5MTNQpFlSeh+j2vZEryCKQeoFY4Ly+jzqNdH2RKcrhpV45y4Aw3JcWIIStqPc7nIVFJelZr+WXtfB5MpKDuk2+/YZKvPjsfdYqLE0NCE0MyFbs/Yp8fmswwK0dpL8/Q0nkM3oBCdhExdJmSOoT1Qy/cSyZpUZMqdLddL1GSKW7ZkwcETXccMpM8N6++p6fPlWi7IwCMUGZfTu93Hc5nABGVJOkoBtksE0hBPqtISdaWVvbTuXnlw2q3+j8bdMxQwfcqBlsphpGUA8ksaer9JVBCH0N2ut/5HPoXrKSJStIwxDAAIqyeunxK3dCJBO1A8tXj87zs+nEOjGd45nyZV9083e8QjiFemCzoacKyFriOMiWV6q0VTUlZUaPaaGEFSjGkk1ox1FrMV5o4luofvBImc57q8LYKMUzrHIlGchRmvsXUc39NQzqkS8/F1h9e+mPviCKNx86o/ff2YgiRzqrzqMebrujZqS8cbpjOUWxZw01JrY4pKY3yMUT+gJWikjSqA8JVe/HKw5PU/DYPPacHmtjAb2tCSGZiy9Kd95NZl3kxil05T1ubkrwBRRbD3z1uSsp7YV/wBK+8YZKpvEc5SCrCq5eokOKW3UqdVJxRSI9zYq5CQqjCgmca6rpHRJk9ITGsw8cAgNOvGESzQk24ZFNJSjKtZum1BRAJfGdAAmjof1mjn8GqK5KJusRBVAxxqeZTSDkIN0tW1CnXewb40GRV2NdvSgr9C6OHjGLQMMQwAKEZgKVT0SzyqbNFlms+b7x7P3/+L1/Ch992L+98zU0r7iceZSJ7HZ1rQMeU5A8xJWlioEpV5zL40ur4GOo+i7pD2mr+jem8q5rQxKqEAlEeQ7HuYyUEExk1INSTo9AoUvV28YH29+BUzqp1h/V71tgzor6Hx2e0YhhiSsoWRgBolOPEoCt3ummm8i6VwOl0ESvOwOf+f5HTvBFTDGlqtALZ6c8wNCqpQwy1IVFJcbzkunEcS/DFZ3SHtBgxONqE5GZHomXJTGfWLISg4U2RaV6IMp/Tbv89ko+cz3Efg1r27TdMkk7aTOZcSm0H/BrCL1MmpYs6wgPTP0xw77/iufkKL7lOXd+RotpXQVTYndX3xToVgzVAMeBXqQtV7K9IGtEoQnWBtjvCrb/0aT7/9Gz3TsLIszUSg9NcUsduDfYxFNLJKJqtUu7xXYQ+hsK+flNSmNw2dsg4nzUMMQyAHVZBXT4d2Z2/fEw5vl563ThCCO69dpxCevBsN0Qy3hWr12yxBniORaXZptQYohiSGSSCrKhRq+vZdORjsCnWfObKzb5aRIMwlXM5X6x3NZyh7asHRSuGvGdH5pWqrdZ76IZ/w5OBrpi6cDxSGMMQlsV4PFIMg8+tkPaoSJdmLU4MYV+LDJNZl5p0CUJ782N/Bl/8dVh6Hug2JaWkWicyJw2NSuo4SKu4K5qSQA3W9xwY4wshMYTfHZDUxJDOdvwKXq7bnBLkdpENSohmkbp0SA1QdSExxBXfeCbJS68b5y0vOQgov89yywa/hu2XKUuP6bzHeMblS963c+7AD1D3A1598zSOJXh8QT32u5M1spYmy3UrBv3dxUpiJPwqDZEi59mUZFo166ktUnMKNFsBv/yJJ1USZYiojMjaiMHz1b1gt2O5K9rHsFxtUkg5WCml9qvxCQUo8nHSKp+jVzEsn1QmpmTWmJI0DDEMgBtGkpTPRYrhy8/Oc3gqG4V2rgVdcekbVAzzZR1ZMyhcVQjaTpYcNeqaGGTCxrZUie5AwunF6pqIYTrvMVdu0E7GTEmxbmzLtRaFlBPNoo/u/n549S/zxOirOCF1Mtv8sSghbhg8x2Iim+TEnAo5HOZjGNX1klrxblx6dprOZJjIudrhqgeJsNG8rpPTbLdJCfWQuzpKpdJLDL3KxklF514juaLzOcQrb5jk6XOlLjNcWwo8PbnIeLr2FpDOdUfmJEdUWGeqcpomDq7d/zgWBigG20rwv//Fvbz0epW0NpVzWWzayGYFp1WlnkiRTlpM513OLdd5Tn/XN0znuH4qx8PnWrSw2O81Yv0M1qkYwvIdMVOS3a7iWx6unaAkMth+CWoLVC31vRyfq/AnX3u+sxNtSvrHJ05w33/9h8FJgzGkWwOIocfH4Ohnt17uIZtmWQ38OrP/4ZOLHd/Q0ilVCsZy1uzv2EpIKfn+3/pHPhaPcLvEMMQwAF4mVvcoNUqzFfD1Ewu89Lrx4RsNgOt1yCDRa89ey/a2xQXdYzjfW1lVI0jmyFKjoYkhnPmFRPL8/NqIYSqvnMLzvl63vtzVi0GZs5wohHPWPQAv+9dUmm2eR1fsXHh2VcUAndIYdmK472M0naQsU9219fUglM0oxdAgiQgHpoXj6lU7GRutgLRWDGG7yUgx+EMUA0TmpJr0hoarxvHKG9Tg/MWjcxExlEmR1teVcizKuhVnbqSbGHKTKsnNq5zBxxlo7utEJQ0nqamcqxzx9SUStJGO6g2yK+9xrtjguCaGgxMZbt6d46lzJYpk2ZWsdWbI61QMUYnwmCnJaVXxrTRCCOqJjGrWU11kmSxJK8FLrh3nv3/2aCfnQCuGbx19nmcvVPja8SGl3DVygRrsnXbMr9SqITUxFFIOybQyJTWrvYqhpMtwjIBs82O/+xn++lt6IF4+BYX9mhguvmKoNNs8dmaZJ8/unF7VhhgGIHR8qn/GePjUEjW/Hc3Q1op4wlIiuX5TkmsnVNVThigGVNOWrKhR1z6GhC71HZqean57zaYkgNlKSz2w9aWOYtB5DIWUE5lXar4yCZQbLeWsz+5Ss/ZVnM/QMSeNZob7PkYyjioJMiDBLZvJMplzqckkVtBUpTJ6iKHZCvA0MYSZsFEuQ2uIjwEic1Iz4fUV9xuEm3flmci6ys+gQ33LpKJyGomEoEKahnQYK3QXWhzfpUxw4/5ZfDH49w0nBCtlzU/nPWokVWkLAE+ZU6byKqDgubkKnpNgV97jlt15ZksNFoIMk1Z1w8RgD1AMyaBOK+pDkcVrl6G2wILMsqvg8QvfdzNLNZ/3ff6YPk/1nJ09r3wPn32qxwcRR7tFDkVwjuxWDE2RJJCqy5yrHfzN6gAfg5uNzH15WVGRWkGgTMYj+yHhXBIfQ1jOo+EHq6x58WCIYQCy2W7F8OVjcyQE3Hvt+hSDF1MMlrvyLHoQXCcRlV0Y6GMAcLVi0GUVRKQYOgPJWk1JgPIzeCNKMYT2+5hiCM0dYanvSqOlzBzj18dMSSsTQ6gYhuUwgLKpV0h1yn0AjboaGHK5HGOZJA2ht68tQVHP/kJTUiwqydZF1aIQRk0wf/HoHC9/z+e67d5aMbTX6BNKJASvPDzBl45eoJ3UkUDSIx1TGzWRVpVVsz2d6vYfAiBDndYQYgh/u2ETA1CkXpcdU5DQJppdeY/5SpMj50scHM+QSIgoWmmJLCOivGFTkhP6z2KKwZU1AickhjyObEJ5llk/w66Cx617Crzuzj38ydeeV2ajKHO/RMqx+NzTs92Z5DG0w7BXOqZBpAS/Rl0Xm8ynHFI6CqzV67doliGZi8JmC6LC2aWaqiTcbmrFkLwkUUlLujx+ZNraAdhxxCCEuF8IcUQIcUwI8XOX4hxyOiIGgPQYX312ntv2Fvr6BqyGVCwuvbdy5lrg2oNj1+MQXo6cqNFsDlYMsDZiiBRDGJnUZUrKRNnXQghSjkVND7KVZkuVaxi/DuaO6j4HK5NgRzEM/z6FEDQSaaxYCeVKRb0fyeVwrAQiJKDZJzobamJQUUlqJhbuI+ri5tfASvLYTInTizWOX4iVWNA+pcBeO5G/8oZJFqs+Ty6oQa1CqstxXUuko14MceRGp/FRv6svBv9GL7xmlPf80O28fAW1OpV3qdHZPrSzhxnt33h+Meqkd3NIDDJDNihvWDF4SZs6ncxzKSWerCH1b9/W1WUJfGZ8lYkN8EN376PSbCuFpU1JOar8i1dey5mlGkeGtE6tLCk1sSzTuFITQ9sHJHWpzn0k5eDpSV2YhR2hUeyYktDEsFzvhKpGPoZLSAxGMQyGEMIC3gd8D3AL8MNCiFsu9nkUYsRQc0b41qlFXnrd+sxIAKl0jBhWyAYehrgzchgpJbw8WWLEoG2/8RnmWoghbAd6PnSi1pejZkXS6dhwAdJJK1IM5UZbmTnGr+9kua5yrWFfhtXOy7ezql+yRq2qiSGvBh0n7LB2vkMMvnZWq6gkraKCJg4tKmEhvVYd7BQXtGP/qbhtN1IMa/+9Xn5Y3RtfeHYZP+FRJtX12z3s3sNngxf2KyQhWEwoImonhvy+CcE/+7Zrujru9WIq71GjM+MPI6LCnJNqsx0Rw2gmye6CxzJZvNbyhhWD51g0ZDLavua3SVNHJnUfCrdjjj1dd9lVUL/5vdeOM5J2+NvHzoLj4eOwL+Xzoy9WtaOGmZMqi2r5OTEZRZuFJsGKLqpYSDlRc6WgvoopCU0MyzpUdSM+BinhC78G3/pf/X1D1oEwCbVuFMNQvAg4JqU8LqVsAh8GXnexT2JsZCR6/8mjdfy25P7bdq17P2nXpS2VndoJQ2DXgfjgMsyUZKXyZEWNpvYxWLrmTdxZvZLJJkRf9nNtqVOCQnj4bRkRg+dY1Jq6MUpkSor1X1ij83lYDkOItqP7JWvUaooYQlu9GyaEnX88WqdUWgK6ayUBKhs2HpXkeKqdKYOJYTVzWBwTWZfb9ub54tE5alaWukh1+U7+vvBGfjf549gDBveaq/okBIn1zdjjyLl2V2a9lxkBYDrXMWWGnQFBqYZlsliN5ZhiWB8xpByLJjaBduSX6i0yNDrJobHud3PtbJS/4lgJXnPLLj7z1Cx1v02JFNfm2kznPW7fW4gqFveivqxCghftKUUMQRANxpVA3Zcj6aQa/OkptAfdzmeUYji3XCdYDBWDNiXJdqeA5GqoL8Pn3w0fewf85h3wtd9b23Y9WKoZxbAa9gKnYv+f1su6IIR4mxDiISHEQxcuXNjyk8hn0jR0vfk/fqTEa2/fzQv2j6x7P6mkFZkKBlXOXA1uzE49LCpF6L7PLZ09GxJDvITGWHZtg85U3uNCKaYYtFmm3O72W6SSVhRaWI77GEKs1cewimKQySxe0HnAG7UqDWkzkVPbezpmXZ5/ggUKtKWgVes4n1M0kbovQoZ61GgIvw62y5xWDF3RIGEuwyrk1otXHJ7km88v8pXc/XzJvrfrs3TSjspt9yLsy7AZYhBCkNQOZ4B0Ts3Ww05+ANfGiOGf3rOfa/fvUwX/Qh/OOovohe09I2Ko1nGFT0IPzMQUwxLZqJQKwPfcvotyo8Uffuk4y0GKvWn1u9x38xTPnTrJ/GJ/v4RmST3nJU+FRrfDZEqg3FbPSUGXxFAb9JiSdLhqoIlhylL1xRrnj0BmCtwcvtTP21od0KGp9a5/rkqN/91/6PSKXweWKkYxrIZBYSB93igp5fullPdIKe+ZnJwcsMnmkEgIakLdyAtBlp/7npUznIfBtRMRMSQ3oRhyrj08QsbNkRH1iBhs3TUuXst/LYoBwiS3hpLbMR9DURNDqBhSjkU17mNIWjB6UNWVglWJYSTt8PPfezM/eFcf5/ddW5KWassINOtVGjiREzeVDonhSZ4Npqng0dZRTGGCm8yo6rcTyWZMMdSUKUkrhq5WnSPKpNF0h3ftG4RXHJ6gFUjeufADfMH7rq7P3v4d1/Fz9w++h+yC6l0QrDfBrAfpTIcYsnnlYB1NOyS1Sokrhvtv28V3vOBG9U9Zm27WqxiSqsNgWM6jqpv02Nq8l4iV/1iUucivBPCy6ycopBze9/lnKZFm0lG/w303TfNnzn9k/m9+qe94rbIKZfUzutdDtRQphlJLPWMjaQcshyYOiXi/8LavVKKb53zdwpcWN4zodrjnHofpW5BS8v6vrLOLWxi1d/CVihxgXdViQxjFsDpOA/tj/+8DZi7FiTSEupF/4KW3sH9s/f4BUDO5kBi8TRDDShEpUWRHYwnors8UzvBXKqAXhyqLoRVDsxTd5Mv6wQvNWamYj6HSaCvFYLvKTgurzraFEPyLV17LtZPZFdcLC9GFs79Ws4YvkpFTPpNV2yfaDZ4LdlEhhdROx5bfwBFtyKqJw7jjx4ihQWB7FOstxjJJLpQakXrg8Hfz1vRvUc3Eb8PVcfeBUdJJi2K91Zf/cO+140Or8GbGVS6D3ECRxTjSmY7pJj+iiEEIwVTeJefZ/X0vwqJ2ZW26Wa/z2VbNekLFECaU2bpcuh3LAl/U4aohHCvBq2+Zpua38e0MXlvNsm+d9jiUOEfrwtG+48nqAnXpYOXU71mrFiMfQ7FlkbQTUUnzRiLVFbQQDdZulufmayyT4bpsiwQB7sIRmL6N2VKDueo6K6xG4dzpThb3BojB+BhWx9eBw0KIQ0KIJPAm4OOX4kRadpo6SX7qvsFdz9a8Hx2GGM5u1wMv6t61QgZu2JOhoeS343Qe8LznkPPsFR2XcUznPS6UGgThTa7bVC756hriiiGexxDF2IfmpHWaYYbB1tE1jcoSAK1GnVYseieX7QyGM9YeqtJFahIJS2UI3eN6PNmMmZJq0X7CaJ/IzyAET7X3rloOoxeubUXhzKvVWIojP6UJaJPEkIl9FyOFTumNvSMprp/K9ueLhAN36TwkbEisbyhwe0xJDZ1QFvbRSGY751Cx8n3E9NrblUnIzYxGtZIS5bMkkHjNBXqRqM2zSI5sTt0TfrUSKYZl31KVVTUaiXR3PaWIGHI8P19hWWbY4zY4IM5jBQ2YuoWj58vRJG7txNBJAH3wrBrcW7X1J6ktm6iklSGlbAE/Dfw98BTwUSnlEytvtT2YGB3FyowPzx9YIzrEsL2KIakLjHUrBmdoh7RBmMq5BBLKQp9r6SwgWGyq84gTQ73Zxm8HNFtBp1zDFhNDWIiuuKxIT/o1WrG+FrlcJ99kZN+NKiFO23gD/RoSw5jd7HI+hzkQYURR3AFdbbbXNbiHeKXe11pKaYRwRpRp5MDU4Paxa0VefxclmWIs25mdv/sHb+PXfuiO/g0ixXBuQ6SUcizVMEmHq9YravB1w+KB6TyBFNRxGSvk+4jpZddP8OpbppmemurUStJtUbOtfmKwGksskyOpiadRK0UD81LT6ora861UlO0OdPwNySzPzVcpkaEgKtxmadPR9K0cnS11iGHNPoZOyZhPHlHHqJQG9JNeBaEpySiGFSCl/Fsp5Q1SyuuklO++VOfhpnM42fWHqPairYkhvQHFEJpMhpXDUCupB9EJFUOMGG7clYvi1teCsA7UYqAH9tI5VSdJx/+HBJVKWlT9VjTQ9hPD+h3tgxBG15SLmhhaddV4RmMk37m2m269iyoeiXAQCJPztHO3YHUTQ13H/d8wnWM67/L02Y4JoNZsr2twD/GKG5SZY11qI6dmztnM5sh0JK9s+hW8rvvl+qkch6cHlLwOiaF0ft2OZwjDVR2kVgy+NuF5mhiyKVXralFm2R0zI4VI2gn+4M33MDkx2amuqpMU8+1FFQoaX7+5RDmRx9ZOdr/WSc5bbCaUf0HDt7uj2XoVQ8MpkKgvcrc3Q0ACJm/k6Gy543xeq49B32NzDYuHzql7q15eWtu2MSzuwMzn9d/9Vwte8tOd0gmbQJCwIdhgrSTdI3pF1aIVg6sVQ9LpDJy/8oO3r+t4YZLbnJ/iAKhS1k6KYt3X5xH2AVDhqmHtoaiJzE2vhbOPwMThdR13GDxdmqQWPmytOqQ71zcaKzHxgjvv4kuf8jomhHA2l1GD9YjViCW41anb6lomsklu3p2PIpNa7UCFum5AMVw7keG6yczAgXAocjoMep15BL0YHVHfRU2k19ZCNiSGZkmVM1knUkmLJRzQM/NWTQ2+nvZ15HTp7WW5yvcRtvcMS1MAHk01y3c7hOb5S1TtaxjVzu1WvQwttd/5RoJCrvOMtO00XrCAlFJ9F2HJbTfHibkKgVeA2glusU4zI/eyz0lxbLbMrsiUtMZCevoe+8KJCmXdZ7vRW7xvDQhNSasVEbyYMMQwDDfevyW7CRXDRmbR6zElea1lSIA7oKb/WhGWxZj19SBVOguZCZZrPlnXjuLw0zpctaob0UeKobAXXv++DR+/F5ncCAD1SpFmK8AKmohYqYrRgiKOZWuMQmaEhkhhtVR5dBESgzYljdpN5pb1TLBVo6ITyiayLjfvzvPlY3M0W0Ek5zdCDEII/uLtL+3KWF8V3ojKts5sLrpufHQEgKa1RuXhFlBBgHJjisFWpiShZ+1hpnHoY8h6NkWZ0Y7nFe59L6/OoVnulDUBFS0VI4ZMa5l6apSkDlFWxKAIcKGRYF+qcw2BkyXFDI1WoPx0WpHIZJbn5xewdo1C+VtcGzR4RB5kH3BstsxYRAxrjUpSE8f/c7RII6EIq1FdWtu2GlLKmClp5yiGHWdKutIgrSRtEiqrcp1YmylJPTwjqBmb42585jmhY+1n6nofse5t8XNQzud2pBgyq3SH2yiy2onarCwxs1TDo4mIFSO0dIZ1ckoplKaVjgrmJUK1lx4HkWDK85krNyjVfWg1KAfKMe85FjfvzuO3Jcdmy9Q02a3X+RxiJJ1c37ZCwE99AV7yjg0dL8TkiK4RZK/Rl5VIdBzQG/ExJJXzWeh+DO1wVq4zn3Oew3tab+K9rX8SJbcNRLxZT7ETgNgsxhLdgoCMLOO7I5GPod2oRAPzXL2nMkAyQ0bUO9V0tXlx3k9S89t4uTGoLTHhz/BIcy8XSg0WKk18NpbH8ODpGi+79SDQUU5rRanRoh1Isq5NsxUMrRV1sWGIYZuxZzy/YZv7ehTDqCYGN7lxYkjaKvv5VD22DyfF8/PVqIwFqEGzHcioKuRKlT83g0JB5RK0aiX+55dP4OIzmo/Zyy0HRILULkUMvpWOnI4iihhJQzLLhKMe9ufnq+DXKbUsJjUR3rxL7fOps8VIBW1EMWwYI9dEA+pGUch4NKRDy1mHLys0J20gh8K1lY8hJAYZ+nR0glnWtflCcCcPypu7ktv6dxRr1rN8mqqrFF518VxnnfoSFgGBO4ob5q40OlFJCz3OZ9wsGeqdarqatJ4v6zDnwgRhetRTwf6o3LdMDIhKqhc7pqhe6JDYGi5veNH1+NIiWGdU0lJFt8zVda0aO0Q1GGLYZqS8FNZGiWEdPoZRoW283sZNSQC7RzyOLcooWU06aZ6YWeb2vSPROmEYbZggtl2DqKcrZS4vLfCnD55iwpOk49FdQsDLfgbu/BFAhRgnZR2CoONrSGYgmWHEViR2Yq4CrRrLvh0ppEMTGVw7wZeOXogS91LO5WVlFULQtj3GRteRmBcSwwZMSamkMiUlNDFEVXB1RFo8xDqe3NaHeN/n4hmWR1V4eHMpRgw1HXyQHsPViiFoViMfYINkl/M5kcySodZRDNr5fFyP2YXxqWjdp+Q1UWvWae2n6TIl/flb4eP/9+Bz15OPa3dNcOc1I5RJEayxG12IpZo6VpjnsVMc0IYYthtWcsOKIZwFTeRWeHATFn4ixYiuVe9uwpQEcOe+ER45vYzUtfIrQZK6H3Dn/k4ma0gEc+XtVQwkLGq4nDl/gUBKRt2gv0Xqq34JDr4MgMDOkEBCq0YibObipCCpGsQDPHehBO0mS74Vfa+2leAtLz3IXz88wwe//FzXNV5OSL/gh9j/bd+/9g0ixbD+e8ZzLOokVTe1douEX1EmU+1Ed+0Ets7W37Wi81nfV+VZqM7TmFTE4MdMSY2iys5OZMZJp7MEUqiwZK0YGjjdxJDKkRRtyhU9OWiWwE7x3GIDOyEYHVPE0HaynJETfOnoHJmkxcSInnTEFUPpHMw9M/DU/XqFqnR59a27SDmWDpfuqIvZYp2f/fC3osnGICxWQ8WgvqOdErJqiGG7EWsXuV5cP5XjT//FvXz7DVMrrufbWRJCSePNKoa7D4xSarTwHTUzW9TJbbfv7RBDqkcxbJePAaAmUmSp8sZ79mO3GytG7wRhVddmBasVMyW5WexWlV15j9Nzava52BSRKQngna+5kVfeMMmffUNFxlyOxMD3/3e445+uff1NKAbPTvBYcAhLtuDMN1S/50RKqTiUgsl6NkldnHH4jvQs/cLTACRGD7IoswSlTpXV6pKa0dvZcVzHooqr/F9+DSls2lhd5lZHZ8zXK7qLmy6g95w2iVppdd3B5M1IEpwr1rl+OkcivLfixNCqK3IYgGa9TI0kuwoeQghqQve51vjKs/P89cMzPHZ6eeD20GnSE5rbjGK4WvCKfwev/a8b3vwl142v2kms5XTMK6kNFOuL454DyhRRQtly5xoJcq7NwfHOMUJTUlhGYtsUA9BIZMiJOu/4zuui/r7DIMMCao0SVtDtY6BR5uBEmtk5ZU9e9J3IlARKNfzWD98VFZvbqPP5ssImFINtJXhA3K7yAJ79LHa7SjPRPQHKeXY0aA5F6HyefQqA5Ph+5mQBUe0Ux6wXVaRZMj+l6pjhkmhVodWIqsrGM5/DxMhG2C9cl9w+fqGifl/tdLd33xb58Q5PZUmEASJx53O7AdW5gdnQ7XqFGm50/zcSaRKxMvELujjebGl4Se4loxiuUuy6DQ69YlsP0daz+7YUpLzNFWPbP5ZiMucyp2PEz9YS3La3QCJGTqlkhxishBjYxH6rkMmPcPduh32jad1HYfgglogqa1Zw2nU1aNmuIoZmiUMTGRoLShGcl2NM5Lr3VUg5fODHv403v+QA10+tPyHxskOkGDZmfmw6Bc5kboFjn8Fu1/Ct7klJ1nVWNiNBx/msiSEzcYA5WcCuzXWOU1QkkS6okN6G8DQx1GjrTPi48znMvm5GxFBCujlOzJVVfa7sNAgLsfeFkf/j+qlsTDHEfAxhn4VyR8F0PqpSk27kT2lYGZwNE4N2PhvFYLBVCPSA2MLetAlECME9B0Y521A36tmK4I59ha51Uk7Hx5BJWmtLqNog8oUx9ni+6usc+Cv6a4QbJ4YajYSnTBvJDDQrHBzPkK2r+k9n5HiXKSnEoYkM/+l1t60vF+FyxSaikkApx6ezL0ae+SbTwSyiJ7Lq3333Dfzsq1ZJdkxmQFgwrwrnZSavYY48bn0+WqVdmceXVlQ1ti48FY7cauBrYhiJVRD2MmE9JW3WaZZpJtLU/YDrJrOQmYC3fxnu/JHIhHN4KovlaHKJJ7hFxNBvTpLNCjWSETH4dha3HSMGbSa6sAIxLFab5FybAiVsWkYxGGwhtBxvYkdmns3g7gOjnNPEUJYud+wb6fo8HVMM22lGAlQW9akH4cm/Vv+vMLu1woiVRhlH1vF16XTc0JSUYY9QA86MnOhTDFcdNqkYUo7F46l7EEjuShwjlekuv3LfzdOrdz4UQt2/QQvSEySSKUrWKJ7fqZckq/MskaWgB/9mwsNu1cCv0RRhK9vOfRgm2UV9nxtFyqgJxbWTmrymbgbLZvdISAw5rJUUwwA/g/Rr1HCj3ieBk8GLleJYKIeKoT708pdrPuMpuOdvvpsfsz5tFIPBFkITQwtrVX/EWnD3gVGKqAeoJpN9iiEkn6Wqv62OZwBe/Z9g9x3wl29T/6/gYwjr6DSqRZLtOr6l101moVnh0ESG3WKeJkkWyDGxxgZGVywixbCxQpGek+CodT1VSxFCOltYZYthO9KEUlD9OSrOGKl2WTVUAhK1BRZlNoo8aiY87EAphiYuuVhWPoDQz0PU97lRZqmtBv3rekq937qnwHTeVU5prRiC0J8gZVQkcKADulmlLpPR5ChI5kjJDjGMLD3O0+5baIdd4gZgqdrkdncWp7HILrGwY8piGGK4AiD0g9USWzNI37qnQEXoRKJkmn2j3eabuGM2vd3E4ObgR/8cRg6o/1eY3Yb9fpvVIklZp5WIEYNf4ZpRj71inhk5Dogu5/NViU04n0E3bGrBA0JVbxXuBpP0wpDVvOpNUXd1e9WK8i141XPMMRINwH4iRbJdg1aNhnQopHuITZu0ZNj3uVFi3le+gN7JwE+89CBf+PffiZUQWLrOWNvXKiFoEfUJK5+nF4lWjSodH0OYWCcDNbhPVI7iCZ908cTQS1+s+txqqb7THk1jSjLYOliaGNpbVPoqaSfIj6qHc2JkpM+HEG9EExXQ205kJuDH/gqu/U7Ye/fQ1SKnY62EK+sdZ6j2PXhBjYP2AqeDsagcxlWNTZqSXMfizGKNT9ZuVQucjRKDjkzSisH3QmKYhVaDyepRjlrXR/dhy0qRDOrQalDD6c56ju2vWNJhos0y5xsO107296VIJER0H4SmpFZIDK2YCWiAYki0atRxyehKvAn9HNZ1N7tkQ5vDqvN924ZYrvkcls8BkKJpTEkGWwdbD4jtLVIMAFNTqlz19ER/Jm3cwZ3ZQHnqDWH0ALz5r2HX8IqxSZ0p3aqVcGWDdmRK0gNWs8IeMc+MnBjoeL7qsAXO56OzZb7Q1v0eNlrWIzQl5RUxtFPaL1GZg/OPY0ufE+6N0eptO6Uy3P0a1aA7uS1+HstLi5SrNWjVmanZXDe58vk5SfU9tP2w2GLM1zBAMVhtpUrDiD1LK9ZycZEgkKT8JQDc5gLNIaUuFqtNDvjH1dcgjGIw2EI4ur9ukNi6QfrAHtUnYP90v/MwHp667c7ndSCd8vClRatWIkWDdlhpNKlnpLVFRoIFzjJuHM+gKru6+Q1Xdk3pki1lZ4L2q98NL/jhjZ1HGLJaUKaksLkS5Vk4800ATqdvjVYP7DSeVIqhEtj9isFJIxGkqPHwMWXfP1e3+/wLvbBDU1KrXzG0ls8yW+x2IjtBjXbM5xVO0CqlJZZrPmNCKYcxUWS+0h+ZFASS5ZrP7oYiBqMYDLYUdkoRQ1Tiewtw250vwrez3HlHv+lGCBGZk7bd+bwOZD2HKi6tuiYGu9uUxPxREsihoapXHSwb/tVX4Z63bmjz0ARz94FRrJf9NOy5a2Pn0aMYrJwiBlmehdMPMS9G8cY7PbgDJ4VHQ5VPb9sUUj2KR4co50Sdx06oUt5lUqsrBt0WN/C181nXgWpIm7lzJ3nRr3yWbzyvzUNS4gR1AruT1JdMjwBQKy0yX2kyjiKGcUrMFvuJoVj3mZBLZHQElmt8DAZbidC2KbdQMSTGD+H8whkSUzcM/Dx0QO8kYsi4NmVStOslUqKBDIkhNHHMqrILM3LCRCSFKOyDDTSRgo6v6cWH1lG4bxB6FEM2m6ckU/jF88gz3+Cb7Ws5ONGZ7Us7jUWArC9Tag9QDKjIpAOZNk8/r4lBplRy2wpIOhZNaRGE4apaOcwmppgSRRIEqjovQNtX5xCr3RU2lqpXllmsNrsUw6Akt6Wqz82J5/U1eXjCKAaDrYR2tgWJrVMMqyEcFC6K83mNyLo2VekR1MukaBKENarCjOgLKrt2Ro4zaUxJm0aoGF60WWLYdRuMXRe1OS2kHOZlnvaFo4j5o3yrfR0HxmPlNkKiry1SG+RjAEiP8131T/Ou+V8AoIrXvY8BcO0ELWyC0LegTUnl1F4StBmjFGUzx/s9h0hpYmhWlpkvNxnTFY/HRGlgkttitcnNQkUkid13kjY+BoMthSYGewPF0DaKnaoYKrgIv0KaRqcSa0QMRwB4+d0v4FW3TF+is7xyMJlTOQR37h/Z3I5u+yH4199Upi2gkHaYo4B7+ssAPCKv4+BExwwkdPSTkAF1kgMVA//sf3H8rp/jyeAAJ9lFpXB41Wz2pJ3Ax4oRg3pdchVh7UosRiUsQmKIN44KOw761SKL1bgpqdhJcmuU4IPfB2e+wVJNKYZmZg/kdpPaQYph5zzVBhuHJoZ9kxtMMNoAdqKPIe1YVKVHoVnCFT4yrLYa+RiOQWqM//SGb7t0J3kF4a0vO8Tr79q75WG/IymHOVmIej08FlzbNdtPxPIlGjjsH0QMY4eYvv/f8+oH7qTtS77zwOoO9qSVwMcmaOnBXyuGkrcHgGu9MovVUDGoIo1W7Fwy+bCxVJFicZmUUOtOJEodU9LsU/Dcl+Bv38nS3R/kFnESf/IWkk5KOZ+NYjDYMmgbrbXBsMONICKGixWuugYkEoJ6Ik26pUprC6dHMbSbkR3bYPNIJS32rtSEZ4MopB3mpLqn59xraCfzXcECcWKoyyGKATVpCbP2V4tIglAx2MhQMWhfQyWtnOLXOMU+xRAnhqSOSpL1Eo1lXXQvv48RSswta9PTsiriyJmHGDv+Ma4TMyR23Q62h3elRCUJId4ohHhCCBEIIe7p+exdQohjQogjQojXxJbfLYR4TH/2XqEzToQQrhDiI3r5A0KIg5s5t6sK4Yz4IhKDF5mSdo6PAaCZSJHTxBDZouPx9YYYdjxGUknmUQP6EftGDoxnuhLTrB7F0Jf5HMOLD6lkudUcz6CJQVpIXRJDalVQ08Sw1y5GiqHVUMXybC92b9kuTWxolmiF/SQmVf5FvaTLiBeVM5zRg9z71K9gi4Dk3jvASV9RUUmPA/8E+GJ8oRDiFuBNwK3A/cDvCCHCEeR3gbcBh/Xf/Xr5TwKLUsrrgd8A3rPJc7t6YLuqrIF18Wbv6cj5vHMUA6i+z2nUAy1CU1LC6jgJDTHseBRSDhekIoaH/EMcnOh2GlteZ5Cvk+yqrNqLb79BmZBu25sfuk4I17bwsSOl4De1XyBVAG+E6cRS5HyulZVjOel1h8BWRVq1Oa3osuGTNwEQ6C50FGdUhvj974kqsVq77wDHw6NxZSgGKeVTUsojAz56HfBhKWVDSnkCOAa8SAixG8hLKb8qpZTAHwGvj23zIf3+z4H7xHbWc77S4OYuqmLYic5nAD8WV55IDohkMcSw4+E5Cc4mVHDAZyrXcmC8e/BNxoihMagkRgwvuW6cL73zO/sqBA+CG5qS2qEqUBMM2/Egt4tJ0XE+16uqQJ+T6lYijUQa2y+TqIbEoDO2a/NIKZUpqbAXbngNTyRvpypSMHYInBQWAb7fH710KbBdPoa9QLyk4Gm9bK9+37u8axspZQtYBsYH7VwI8TYhxENCiIcuXLgwaJWrD9fcu2K5iK2Gt0MVQ7uLGGIDSuhnyO/FYGdDCMGj7j28c/oPeKx9DQd7wkzt2GDsiySZVXqQ7B9bW2vdpJ2ghRV1a/MbSjE4Xhqy04y1FyNTUr2miMHrI4YMdquCE9ZJmroZgEKg/RPFGcjvASH4mdbP8IFDv6kUrY6gk83ams51u7HqUy2E+Aywa8BHPy+l/NiwzQYskyssX2mb/oVSvh94P8A999wzcJ2rDm/6k4t6uJ0YlQQgY4Xc4k7KyA9T2I/BzsdIOsmnzheAVp9icNOdwdhOprasUVQYlSR0a8+WLvvtJF3I7SI38wyNVkCt2aYZEkMm17WPlp0m2ajgtRZpWUlsXRU4THIbLZ6B6+5jrtzgWDVN6pAijjDJULYuE2KQUr5qA/s9DcSfwH3AjF6+b8Dy+DanhRA2UAAWMNiRSCWV2NxpzmcZUwl2zOQQKQZjSrosMJJ2ODqrBt9DEz3EkOoMxpa7NjWwFriOymMIFUNbz94dNw25XWT8OUCyUG3S0r0e0pluxdBysiSr58kHy9RTo2TTKoR1XBS5sFzixtI5yO/h6Hm1/Q3T+lpCH5i/M4hhu0xJHwfepCONDqGczA9KKc8CJSHEvdp/8GbgY7Ft3qLfvwH4nPZDGOxAfO/tu/nZV62eNHTRkewMGnZ80EhmVQvJ3CDxa7DTEPoNPCfBVE+WuhcbjB1368Jlk1YCX3YUQ1s7n5NeCrK7sAKfEcosVpr4Oiopne5WDEEyR1pWGRMlmu4YWA5td4QxSpQunAYkFPZydFY5rw9P62vRxfjE5aIYVoIQ4geB3wImgU8KIR6WUr5GSvmEEOKjwJNAC3iHlDKMw3o78EEgBXxK/wF8APhjIcQxlFJ402bOzWB7ceueArfuuXgJdWtF3HwUt0WTGoWR/cqea7DjERbGO9gTqgqQdpPUpYMnfFxv6xSDbSVoCQsRqJ7Pbb9OU1p4jgM55QyfEkssVX1yDZWXkM12EwPJLDlRY5wiQUplTIvMOGPVIvUF7V7N7+OZJ0rkXDvqOR0qBuEPbwN6MbEpYpBS/hXwV0M+ezfw7gHLHwJuG7C8DrxxM+djYCDc+GwyZoL4rp+H2uIlOCODjSBUDIPqG6Uci2VcPLaWGEBVKBaBGpwDv0GDpIrAs5TSnBJLLFabZBpVqtIl1xMRJdwcGeqMU0RkVTBIIjPJ1HyRk4shMezhmfPLHJ6ONQ7SPgarvTMUg8l8NriiYKc68epdoYSjBzdeFtrgoiMsjHewx/EMYCUENdRAmkpn+z7fDAJhkQjCBLc6TWw8JxGZICdRxCD9KnWSXb1JABKpPGnRYEIsY2V1GY7MBJOJMlZZuVNlfg9Hz5c6/gWIopJEe2eEq+6skBIDg00i7PsM/clHBpcPQmLojUgKURfK7+Clt/Y3bgunQwytBg0cPNuCbMeUtFjxoVmlIdw+M1c4MUmJJqKgCzWmxxkVRezyDCSzzPkei1Wfw3Fi0OVb7HYdKeWWRVptFEYxGFxRSOoZZFW62Ja5vS9XhKak3qznEA2hFENmi4khEA4JqXwMslWnKR1lSnKz4GTY56heC6JVi84hjrBeEkAyrzvRZSbJByWc8gzNzO4o2uqG6Zja0cTg0aQxpA3oxYR5cgyuKLj6wazRP5szuHzwsusn+JEXX8MLrxkd+HlTqIE0k9liU1LCJqGdz8QVA0Bumj1WkaVqk0Srhp/oJwY3MxK9T2R1W9zMBAna3JQ4xcn2KM+cVxFJNwxQDDulWY8hBoMrCl5GEUNoajC4PDGRdfmVH7x9aElv31KDci671cTgYMmw7HZD+Rh0zg7ZXUyJZRaqPla7RsvqJ4aU7skAdHpppxVBHBTneLSY4dHTy+Q9uzsMV/sYUjukkJ4hBoMrCpl0moa0qWOI4UqGn0jRkgkK2S0u+51wsLQpKdFWUUnJ0CSZm2aCRZaqTex2nfYgYsjEQrjTuqJPplPZ52RrlI89MsMN07luRaujknZK6W1DDAZXFDKuTRWP5gD7r8GVg5aVGt69bROQCQcLRQyi3aQlnM4Anp1mNFhgsdrECepddblCJGJRcWS0KUkrBgCR30s7kN2OZ4gUg2cUg4HB1iPjWlTwBjoGDa4cXPCu4Xk5HSXCbRWkZXcUQ9CgJWL7z07jBVUalRJJ2UDaA9SKLr3SFnbUQCsiCODOW28FehzPAIkE7USSlGhS9xUx/JuPPMxvfuaZLbqy9cEQg8EVhUzSpiI9mgljSrqS8aXJH+W1zf+8DYohiU0bpCTRbtJKxIhB5zJ4zXk8WY8cxl3QbXat7CSESiPdMSW95K7b+b9efojvvX1336aBncKNRSV96egFPvPU+S26svXB5DEYXFFIJy1+u/16xtOTvOhSn4zBtiHl2qQci6S9xXNbSxNN28cKmgRxYsiq8NMpFvFodhpBxaGJIW4+wnaVemgUcceu4Re+b3DTIGl7pGhQ99u02gHzlSaleot2ILESFzfCzhCDwRUFIQSft1/JTanc6isbXLZ4w937usM9twphs6t2Ezto0LZiyjPbKYuRotHd7yPa3lEF8WLmI6CjGrzhneSk7UXhqnPlJveLB1ho5zm58Mq+CrPbDUMMBlccMu42zCQNdhTuPjDG3QfGtny/ImyPG/hY0iew+k1Je8Q8tgiGl/x2c/3EkJlQymEl2Ck8fOqtNueLdd5pf5jTcpIj5/65IQYDg80i49qGGAw2hkgx+Diy2U0MqTGksDkglN3fdocM1t/9bhi/vnvZ3T8BrVUqpzopUjSY8wNmSw2uERUc0eYvz5e4/7bucvFSShqtYGiex2ZhiMHgisN9N00xmTPOZ4P1Q8RNSdKHeBBDIkGQmeTAsiaGYbW47vxn/cvu+tHVj+2k8MQC9VabetEnT4UCFZ49O49qadPBcs3nBf/p0/zy627lx15ycA1Xtj4YYjC44vDzr73lUp+CwWWKhB06n5u4NJE95h+R28U1RVUlNbnFfiyRTONxjoYfUCstYgnVp6xy7ihwb9e6Z5ZUee7tmgAZvW1gYGCgESoG2VQd2rC6B95Ebhd7xRyw9ZVdE44XJbhVli9Ey+3FEzR7CuvNLCmz1O7CFmd+h+eyLXs1MDAwuAwRKoZWTRW6w+mZkWencIRKQPO2uBdEwk1HJTHqxflo+X7OcmKu0rXu2WWlGPaMGGIwMDAw2FYktOkoJAZh92TQx3qGbzUxCDulMp9bbZrlhWj5IXGOI7oia4gzSzWSdoLxzNZmfocwxGBgYGCgESmGehEA0Rtiqhv2ANju1hIDTjrKY2hXVRtamcxybeIcz5zrJoaZpTq7Cx6JbUp8M8RgYGBgoGFp01GzoojBSvYohhgx4Gxtv2m0j6HWbCPqSwCIvS/kOut81MMhxMxSjT3b5F8AQwwGBgYGESxbmWYalWVggGKImZIG1kraDOwUSVqcXSqTk9qnsPduJuU8z5+b61p1Zqm2bf4FMMRgYGBgECHhKGLwq4oYbLdn8N1WxaCOdWFhiYKoEAgbdt2uzmvpBLWmcnq32gHni3X2jmxfBeFNEYMQ4teFEE8LIR4VQvyVEGIk9tm7hBDHhBBHhBCviS2/WwjxmP7svUIXOxdCuEKIj+jlDwghDm7m3AwMDAzWi9CU1KqX9P+9pqSpzvtBRfQ2A00MC8vLFKjQdgtRBvUBznF0Vp3T+VKDQMLuHawYPg3cJqW8A3gGeBeAEOIW4E3ArcD9wO8IIcLc7d8F3oZK5TusPwf4SWBRSnk98BvAezZ5bgYGBgbrgqMVQ6CJoU8x2C6kdB/q3oilTR9cHctuNyiICqRGYOxaQEUmPTmj/B4zS9sbqgqbJAYp5f+RUne1gK8B+/T71wEfllI2pJQngGPAi4QQu4G8lPKrUkoJ/BHw+tg2H9Lv/xy4T5hu7gYGBhcRoWKgoYkhOSCzOLtLmZG2enjSROOJJgXKWOlRcHPI7DSHnfM8dkaZt0Ji2LGmpB68FfiUfr8XOBX77LRetle/713etY0mm2VgnAEQQrxNCPGQEOKhCxcuDFrFwMDAYN1wkjovoFnW/w8wF2Wntt7xDNE+PZqMWVUSWpmIseu4OXmBxyPFsL1Zz7AGYhBCfEYI8fiAv9fF1vl5oAX8SbhowK7kCstX2qZ/oZTvl1LeI6W8Z3JycrVLMDAwMFgTbO1TsHwVFeR4AwbfsWshM9W/fLOIEcOoqCpTEsD4teyXZ3nqbBG/HTCzVKPg2WSc7YsdWrWInpTyVSt9LoR4C/B9wH3aPARKCeyPrbYPmNHL9w1YHt/mtBDCBgrAAgYGBgYXCUmtGKxWRf8/gBhe9UuRothS6B7SKdEkTxm8EbV87Dqy/jzJVpljs2VmlmrcVPDhl8fhtf8V7nnrlp/KZqOS7gf+A/ADUspq7KOPA2/SkUaHUE7mB6WUZ4GSEOJe7T94M/Cx2DZv0e/fAHwuRjQGBgYG2w5H+xiclhrOkqkBpqTUCBT29S/f9ME1MdAgLSsxxaAjk8R5Hj+zzJmlGtdnmyADSG5Pp8LNlt3+bcAFPq39xF+TUv5LKeUTQoiPAk+iTEzvkFK29TZvBz4IpFA+idAv8QHgj4UQx1BK4U2bPDcDAwODdcHRzmY3UMTgutvn4O0/uCKGSbFMAtlRDHnlhr3GKfL4mWXOLtc5OKGb/qRHt+VUNkUMOrR02GfvBt49YPlDwG0DlteBN27mfAwMDAw2A8dVxJAKlCnJ9bY4V2El6KikaaHqJEWKIa1amN466vOJEwss13z2eZoYUlvf3hRM5rOBgYFBhKRWDGnUwJtKbV/kTx90JvV06FoNFUNaBWfekGvytC6mt8updH221TDEYGBgYKDhOha+VLm4DWnjOhexyaUzRDG4OUg4XON1ekZPWNr5nTaKwcDAwGBbkbQS+NrC3sThoubY6qikXSExhIpBCEiPs8vuNOsZoQwJB5JbXPpbwxCDgYGBgYYQghZKMfjCubgHt2xkwmG/vaT+T8Ucy+lx8rKI5yRICMi0i8qMtE3EZYjBwMDAIIaOYtie7mgrQTgpsoHKcI5MSQDpMRK1BW7enWdX3iNRW9g2MxJsPlzVwMDA4IpCW6hhsXWxFQOokNVGUZmJ4mW90+Mw+yQ/fd/1zJeb8NjCtkUkgSEGAwMDgy609LDoi4uvGKKKramRbjNRehyq89x3s+4H8eACTNywbadhTEkGBgYGMYSKoZ24FIpBq4TQ8RwiPQ61RQh0nnB1fltNSYYYDAwMDGJohaakxICS29sNJ6YY4kiPqxIY9WWQUpGEMSUZGBgYXBwEmhiCxKUwJemEukGKAZRSSFgQtLYtuQ0MMRgYGBh0oX0piSHs89CnGLQ6CIkhvmwbYIjBwMDAIIYgoYnBuhSmpFUUQ2VORSyBMSUZGBgYXCwEOhpJWjtJMcRMSbbbvWwbYIjBwMDAIIZAz8gviWIIw1VX8jFExGAUg4GBgcFFgdSmJGFfQlNSr2JIppVjujrfIQ9DDAYGBgYXB1IrBnkpfQypAQ140uNQXVDriAS4hW07DUMMBgYGBjFcUsUwLFwVlEKozitiSI1CYvvS0AwxGBgYGMQgdZiqcC5iW88Qw0xJEJXFwEltq+MZTOazgYGBQTcsNV9OOJdAMSQz6nWoKWkeattbQA+MYjAwMDDohg5TTVwKxXDrD0LChvye/s9CH0MyCyP7t/U0jGIwMDAwiEM7nxPORez3HCIzAff8xODP0uPQWIbyuW2NSAJDDAYGBgbd0IrBTl4CxbASQjKoXNh2U9KmiEEI8ctCiEeFEA8LIf6PEGJP7LN3CSGOCSGOCCFeE1t+txDiMf3Ze4VuqiqEcIUQH9HLHxBCHNzMuRkYGBhsCLZSDNaOI4aYw3mHK4Zfl1LeIaV8AfAJ4P8FEELcArwJuBW4H/gdIYSu/MTvAm8DDuu/+/XynwQWpZTXA78BvGeT52ZgYGCwbiQsRQw7TzGMD36/DdgUMUgpi7F/M4DU718HfFhK2ZBSngCOAS8SQuwG8lLKr0opJfBHwOtj23xIv/9z4L5QTRgYGBhcLAg7NCVdAh/DSoiTwU42JQEIId4thDgF/ChaMQB7gVOx1U7rZXv1+97lXdtIKVvAMjCQFoUQbxNCPCSEeOjChQubvQQDAwODCAenRgCYHtu+zOINYSeZkoQQnxFCPD7g73UAUsqfl1LuB/4E+OlwswG7kissX2mb/oVSvl9KeY+U8p7JycnVLsHAwMBgzcilVXtN61KEq66EOBlssylp1TwGKeWr1riv/w18EvhFlBKIB9ruA2b08n0DlhPb5rQQwgYKwMIaj21gYGCwNdA+BuxLUHZ7JdguJHPQLO1sU5IQ4nDs3x8AntbvPw68SUcaHUI5mR+UUp4FSkKIe7X/4M3Ax2LbvEW/fwPwOe2HMDAwMLh4iIhhhykG6KiGQZnRW4jNZj7/qhDiRiAAngf+JYCU8gkhxEeBJ4EW8A4pZVtv83bgg0AK+JT+A/gA8MdCiGMopfCmTZ6bgYGBwfoRVlXdkcQwDvWlqGzHdmFTe5dS/tAKn70bePeA5Q8Btw1YXgfeuJnzMTAwMNg0bvweeM1/hrFrL/WZ9CM9DrXFbT+MqZVkYGBgEEdqBF7yry71WQzGvW9XfZ+3GYYYDAwMDC4XXH/fRTmMqZVkYGBgYNAFQwwGBgYGBl0wxGBgYGBg0AVDDAYGBgYGXTDEYGBgYGDQBUMMBgYGBgZdMMRgYGBgYNAFQwwGBgYGBl0Ql3udOiHEBVSdpvVgAtj+9MGLgyvpWuDKup4r6VrAXM9Oxkau5YCUcmDfgsueGDYCIcRDUsp7LvV5bAWupGuBK+t6rqRrAXM9OxlbfS3GlGRgYGBg0AVDDAYGBgYGXbhaieH9l/oEthBX0rXAlXU9V9K1gLmenYwtvZar0sdgYGBgYDAcV6tiMDAwMDAYAkMMBgYGBgZduCKIQQjxP4QQs0KIx2PL7hRCfFUI8ZgQ4m+EEPnYZ+8SQhwTQhwRQrwmtvxuvf4xIcR7hRDiYl+LPo81X48Q4tVCiG/o5d8QQnzXTrqe9f42+vNrhBBlIcS/iy275Neiz2O999od+rMn9OfeTrmedd5njhDiQ3r5U0KId8W2ueTXos9jvxDi8/r8nhBC/IxePiaE+LQQ4qh+HY1tsyPHgvVey5aPA1LKy/4PeCXwQuDx2LKvA9+u378V+GX9/hbgEcAFDgHPApb+7EHgJYAAPgV8z2VwPXcBe/T724AzsW0u+fWs51pin/8F8GfAv9tJ17KB38YGHgXu1P+P76R7bZ3X8iPAh/X7NPAccHCnXIs+j93AC/X7HPCMft5/Dfg5vfzngPfo9zt2LNjAtWzpOHDRf7xt/CIP9tzgRTrO9f3Ak/r9u4B3xdb7e/2l7Qaeji3/YeD3d/r19GwjgHl9o++Y61nPtQCvB34d+CU0Meyka1nnvfa9wP8asP2OuZ51XMsPA3+DIrtxPVCN7aRrGXBtHwNeDRwBdse++yP6/WUxFqzlWnrW3fQ4cEWYkobgceAH9Ps3om5ygL3Aqdh6p/Wyvfp97/KdgmHXE8cPAd+SUjbY2dcz8FqEEBngPwD/sWf9nXwtMPy3uQGQQoi/F0J8UwjxTr18J1/PsGv5c6ACnAVOAv9FSrnADr0WIcRB1Cz6AWBaSnkWQL9O6dUui7FgjdcSx6bHgSuZGN4KvEMI8Q2UFGvq5YPsa3KF5TsFw64HACHErcB7gJ8KFw3Yx065nmHX8h+B35BSlnvW38nXAsOvxwZeDvyofv1BIcR97OzrGXYtLwLawB6U2eXfCiGuZQdeixAiizJH/qyUsrjSqgOW7aixYB3XEq6/JeOAvZ6TvJwgpXwa+G4AIcQNwGv1R6fpnm3vA2b08n0Dlu8IrHA9CCH2AX8FvFlK+axevGOvZ4VreTHwBiHErwEjQCCEqKMejB15LbDqvfYFKeWc/uxvUTb9/8UOvZ4VruVHgL+TUvrArBDiy8A9wJfYQdcihHBQ98ufSCn/Ui8+L4TYLaU8K4TYDczq5Tt6LFjntWzpOHDFKgYhxJR+TQC/APye/ujjwJuEEK4Q4hBwGHhQy7KSEOJe7bV/M8qutyMw7HqEECPAJ1G20i+H6+/k6xl2LVLKV0gpD0opDwK/CfyKlPK3d/K1wIr32t8Ddwgh0kIIG/h2lM1+x17PCtdyEvguoZAB7kXZrnfMtejjfwB4Skr532IffRx4i37/Fjrnt2PHgvVey5aPA5faQbRFjpk/Rdk+fRRD/iTwMygH2TPAr6Idanr9n0dFIBwh5qFHzYAe15/9dnybnXo9qIe3Ajwc+5vaKdez3t8mtt0v0R2VdMmvZYP32j8HntDn/ms76XrWeZ9lUZFiTwBPAv9+J12LPo+Xo8wkj8aehe9FOcs/CxzVr2OxbXbkWLDea9nqccCUxDAwMDAw6MIVa0oyMDAwMNgYDDEYGBgYGHTBEIOBgYGBQRcMMRgYGBgYdMEQg4GBgYFBFwwxGBgYGBh0wRCDgYGBgUEX/v/BGLRSR1FiZwAAAABJRU5ErkJggg==\n",
@@ -1214,23 +1294,21 @@
    "source": [
     "#rgi_reg='test'\n",
     "#opath = os.path.join(sum_dir, 'fixed_geometry_mass_balance_{}.csv'.format(rgi_reg))\n",
-    "for gdir in gdirs:\n",
-    "    pf = gdir.read_json('local_mustar')['prcp_fac_from_winter_prcp']\n",
-    "    fixed_geom = oggm.core.massbalance.fixed_geometry_mass_balance(gdir, precipitation_factor = pf)\n",
-    "    plt.plot(fixed_geom)"
+    "pd_fixed_geom = utils.compile_fixed_geometry_mass_balance(gdirs)\n",
+    "plt.plot(pd_fixed_geom)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01b406fd",
+   "id": "6a63b9cf",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "c53cb282",
+   "id": "95d019b9",
    "metadata": {},
    "source": [
     "### 3. Ice thickness inversion\n",
@@ -1240,15 +1318,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "id": "0121b109",
+   "execution_count": 61,
+   "id": "e71b1f5e",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-05-30 16:52:08: oggm.workflow: Execute entity tasks [apparent_mb_from_any_mb] on 2 glaciers\n"
+      "2022-07-07 11:14:15: oggm.workflow: Execute entity tasks [apparent_mb_from_any_mb] on 2 glaciers\n"
      ]
     },
     {
@@ -1257,7 +1335,7 @@
        "[None, None]"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1277,8 +1355,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "id": "46aadead",
+   "execution_count": 62,
+   "id": "23db8705",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1287,120 +1365,120 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
-   "id": "5c4054bf",
+   "execution_count": 63,
+   "id": "7ec0d990",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-05-30 17:14:36: oggm.workflow: Execute entity tasks [compute_downstream_line] on 2 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Execute entity tasks [compute_downstream_bedshape] on 2 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Applying global task calibrate_inversion_from_consensus on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Consensus estimate optimisation with A factor: 0.1 and fs: 0\n",
-      "2022-05-30 17:14:36: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Consensus estimate optimisation with A factor: 10.0 and fs: 0\n",
-      "2022-05-30 17:14:36: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Consensus estimate optimisation with A factor: 8.970826368757802 and fs: 0\n",
-      "2022-05-30 17:14:36: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Consensus estimate optimisation with A factor: 4.535413184378901 and fs: 0\n",
-      "2022-05-30 17:14:36: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
-      "2022-05-30 17:14:36: oggm.workflow: Consensus estimate optimisation with A factor: 5.3617146998389815 and fs: 0\n",
-      "2022-05-30 17:14:36: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Consensus estimate optimisation with A factor: 5.137832466043701 and fs: 0\n",
-      "2022-05-30 17:14:37: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Consensus estimate optimisation with A factor: 5.112143303712482 and fs: 0\n",
-      "2022-05-30 17:14:37: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: calibrate_inversion_from_consensus converged after 6 iterations and fs=0. The resulting Glen A factor is 5.112143303712482.\n",
-      "2022-05-30 17:14:37: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Applying global task calibrate_inversion_from_consensus on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Consensus estimate optimisation with A factor: 0.1 and fs: 0\n",
-      "2022-05-30 17:14:37: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Consensus estimate optimisation with A factor: 10.0 and fs: 0\n",
-      "2022-05-30 17:14:37: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Consensus estimate optimisation with A factor: 7.102739422138928 and fs: 0\n",
-      "2022-05-30 17:14:37: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Consensus estimate optimisation with A factor: 3.601369711069464 and fs: 0\n",
-      "2022-05-30 17:14:37: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Consensus estimate optimisation with A factor: 1.850684855534732 and fs: 0\n",
-      "2022-05-30 17:14:37: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Consensus estimate optimisation with A factor: 1.5771235995565338 and fs: 0\n",
-      "2022-05-30 17:14:37: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Consensus estimate optimisation with A factor: 1.6583556491050178 and fs: 0\n",
-      "2022-05-30 17:14:37: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Consensus estimate optimisation with A factor: 1.6500638708584927 and fs: 0\n",
-      "2022-05-30 17:14:37: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: calibrate_inversion_from_consensus converged after 7 iterations and fs=0. The resulting Glen A factor is 1.6500638708584927.\n",
-      "2022-05-30 17:14:37: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
-      "2022-05-30 17:14:37: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n"
+      "2022-07-07 11:14:15: oggm.workflow: Execute entity tasks [compute_downstream_line] on 2 glaciers\n",
+      "2022-07-07 11:14:15: oggm.workflow: Execute entity tasks [compute_downstream_bedshape] on 2 glaciers\n",
+      "2022-07-07 11:14:15: oggm.workflow: Applying global task calibrate_inversion_from_consensus on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Consensus estimate optimisation with A factor: 0.1 and fs: 0\n",
+      "2022-07-07 11:14:16: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Consensus estimate optimisation with A factor: 10.0 and fs: 0\n",
+      "2022-07-07 11:14:16: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Consensus estimate optimisation with A factor: 8.877988820236832 and fs: 0\n",
+      "2022-07-07 11:14:16: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Consensus estimate optimisation with A factor: 4.488994410118416 and fs: 0\n",
+      "2022-07-07 11:14:16: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Consensus estimate optimisation with A factor: 4.982155842187974 and fs: 0\n",
+      "2022-07-07 11:14:16: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Consensus estimate optimisation with A factor: 4.835335852841144 and fs: 0\n",
+      "2022-07-07 11:14:16: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Consensus estimate optimisation with A factor: 4.8111591735759385 and fs: 0\n",
+      "2022-07-07 11:14:16: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: calibrate_inversion_from_consensus converged after 6 iterations and fs=0. The resulting Glen A factor is 4.835335852841144.\n",
+      "2022-07-07 11:14:16: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Applying global task calibrate_inversion_from_consensus on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Consensus estimate optimisation with A factor: 0.1 and fs: 0\n",
+      "2022-07-07 11:14:16: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Consensus estimate optimisation with A factor: 10.0 and fs: 0\n",
+      "2022-07-07 11:14:16: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Consensus estimate optimisation with A factor: 7.066749511317489 and fs: 0\n",
+      "2022-07-07 11:14:16: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Consensus estimate optimisation with A factor: 3.5833747556587445 and fs: 0\n",
+      "2022-07-07 11:14:16: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Consensus estimate optimisation with A factor: 1.8416873778293723 and fs: 0\n",
+      "2022-07-07 11:14:16: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Consensus estimate optimisation with A factor: 1.547851526512993 and fs: 0\n",
+      "2022-07-07 11:14:16: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Consensus estimate optimisation with A factor: 1.636017603300028 and fs: 0\n",
+      "2022-07-07 11:14:16: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Consensus estimate optimisation with A factor: 1.627837515282528 and fs: 0\n",
+      "2022-07-07 11:14:16: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: calibrate_inversion_from_consensus converged after 7 iterations and fs=0. The resulting Glen A factor is 1.627837515282528.\n",
+      "2022-07-07 11:14:16: oggm.workflow: Applying global task inversion_tasks on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [prepare_for_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [mass_conservation_inversion] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [filter_inversion_output] on 1 glaciers\n",
+      "2022-07-07 11:14:16: oggm.workflow: Execute entity tasks [get_inversion_volume] on 1 glaciers\n"
      ]
     }
    ],
@@ -1426,15 +1504,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
-   "id": "116f290e",
+   "execution_count": 64,
+   "id": "7ae88382",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-05-30 17:14:56: oggm.workflow: Execute entity tasks [init_present_time_glacier] on 2 glaciers\n"
+      "2022-07-07 11:14:20: oggm.workflow: Execute entity tasks [init_present_time_glacier] on 2 glaciers\n"
      ]
     }
    ],
@@ -1449,8 +1527,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
-   "id": "0e49eb02",
+   "execution_count": 65,
+   "id": "ef622e44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1459,18 +1537,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
-   "id": "3ac903d8",
+   "execution_count": 66,
+   "id": "1ae9a8de",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-05-30 17:14:57: oggm.utils: Applying global task compile_glacier_statistics on 2 glaciers\n",
-      "2022-05-30 17:14:57: oggm.workflow: Execute entity tasks [glacier_statistics] on 2 glaciers\n",
-      "2022-05-30 17:14:57: oggm.utils: Applying global task compile_climate_statistics on 2 glaciers\n",
-      "2022-05-30 17:14:57: oggm.workflow: Execute entity tasks [climate_statistics] on 2 glaciers\n"
+      "2022-07-07 11:14:20: oggm.utils: Applying global task compile_glacier_statistics on 2 glaciers\n",
+      "2022-07-07 11:14:20: oggm.workflow: Execute entity tasks [glacier_statistics] on 2 glaciers\n",
+      "2022-07-07 11:14:20: oggm.utils: Applying global task compile_climate_statistics on 2 glaciers\n",
+      "2022-07-07 11:14:20: oggm.workflow: Execute entity tasks [climate_statistics] on 2 glaciers\n"
      ]
     }
    ],
@@ -1478,13 +1556,13 @@
     "opath = os.path.join(sum_dir, 'glacier_statistics_{}.csv'.format(rgi_reg))\n",
     "glacier_stats = utils.compile_glacier_statistics(gdirs, path=opath)\n",
     "opath = os.path.join(sum_dir, 'climate_statistics_{}.csv'.format(rgi_reg))\n",
-    "clim_stats = utils.compile_climate_statistics(gdirs, path=opath, winter_daily_mean_prcp = True)\n"
+    "clim_stats = utils.compile_climate_statistics(gdirs, path=opath) #, winter_daily_mean_prcp = True)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
-   "id": "046b25be",
+   "execution_count": 67,
+   "id": "05d70a0f",
    "metadata": {},
    "outputs": [
     {
@@ -1493,7 +1571,7 @@
        "1.7765151972292408"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1504,7 +1582,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1cd1cd48",
+   "id": "02f80b53",
    "metadata": {},
    "source": [
     "---"
@@ -1512,23 +1590,37 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f2ff7466",
+   "id": "01b0799e",
    "metadata": {},
    "source": [
-    "## Start of Level 5 tasks\n",
-    "\n",
-    "--> ATTENTION: at the moment run_from_climate_data does not take the right prcp. factor ... \n",
-    "-> I just do a loop here to prescribe the right prcp_fac \n",
-    "\n",
-    "**--> instead could use the same approach as with `apparent_mb_from_any_mb`**\n"
+    "## Start of Level 5 tasks"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
-   "id": "cacea5bd",
+   "execution_count": 29,
+   "id": "9a577bef",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-07-07 10:14:39: oggm.workflow: Execute entity tasks [run_from_climate_data] on 2 glaciers\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<oggm.core.flowline.FluxBasedModel at 0x7fd64cfef700>,\n",
+       " <oggm.core.flowline.FluxBasedModel at 0x7fd64cfef790>]"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from oggm.core.flowline import FluxBasedModel\n",
     "\n",
@@ -1542,35 +1634,53 @@
     "    tasks.run_from_climate_data(gdir,\n",
     "                             min_ys=y0, ye=ye,\n",
     "                             evolution_model=evolution_model,\n",
-    "                             output_filesuffix='_historical',\n",
-    "                               precipitation_factor=pf) "
+    "                             output_filesuffix='_historical_givepf',\n",
+    "                               precipitation_factor=pf)\n",
+    "workflow.execute_entity_task(tasks.run_from_climate_data, gdirs,\n",
+    "                         min_ys=y0, ye=ye,\n",
+    "                         evolution_model=evolution_model,\n",
+    "                         output_filesuffix='_historical')  # gets pf automatically from the json file (actually should give the same result!!!)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
-   "id": "d2999fc2",
+   "execution_count": 68,
+   "id": "93d96906",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-05-30 17:15:11: oggm.utils: Applying global task compile_run_output on 2 glaciers\n",
-      "2022-05-30 17:15:11: oggm.utils: Applying compile_run_output on 2 gdirs.\n"
+      "2022-07-07 11:17:32: oggm.utils: Applying global task compile_run_output on 2 glaciers\n",
+      "2022-07-07 11:17:32: oggm.utils: Applying compile_run_output on 2 gdirs.\n",
+      "2022-07-07 11:17:32: oggm.utils: Applying global task compile_run_output on 2 glaciers\n",
+      "2022-07-07 11:17:32: oggm.utils: Applying compile_run_output on 2 gdirs.\n"
      ]
     }
    ],
    "source": [
     "opath = os.path.join(sum_dir, f'historical_run_output_{rgi_reg}.nc')\n",
     "\n",
-    "ds_hist = utils.compile_run_output(gdirs, path=opath, input_filesuffix='_historical')"
+    "ds_hist = utils.compile_run_output(gdirs, path=opath, input_filesuffix='_historical')\n",
+    "ds_hist_test = utils.compile_run_output(gdirs, path=opath, input_filesuffix='_historical_givepf')\n",
+    "\n",
+    "# check if they are the same: ok, it works!\n",
+    "assert np.all(ds_hist.volume == ds_hist_test.volume) "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
-   "id": "77d7b7d6",
+   "execution_count": 34,
+   "id": "5c0b0f7a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "4459f864",
    "metadata": {},
    "outputs": [
     {
@@ -1579,13 +1689,13 @@
        "Text(0.5, 1.0, 'RGI60-11.00897')"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAEICAYAAABPgw/pAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAqvUlEQVR4nO3dd3yV9fn/8deVRUgICUhARhjKdDDDRpTaarUW9xacpViw2tZa/fbb8e34OVpbrTiKOKrgquKu2LpFZCRsBGRPkQABgQABcv3+OCc0xkxykvvk5P18PM7jjM997vt9ktxX7vO57/tzm7sjIiL1X1zQAUREJDJU0EVEYoQKuohIjFBBFxGJESroIiIxQgVdRCRGqKCLiMQIFXSpFWa21sz2mdkeM9tiZk+aWZMS7dlm9oaZ5ZvZTjP7zMz+aGbNwu3XmNn0UvO8zMyWmtleM1tlZqeUaDvdzJaZWYGZvW9mHSrIlmRmL4YzupmdVqp9RHgeu8xsbRU+a7nLtpC7zWx7+HaPmVmJ9t5m9nF4WRvN7Nel3vtLM1tvZl+Z2XNm1rRE+5Lwz7f4dsjMXq8sr8QuFXSpTd939yZAb6APcAeAmQ0BPgA+Abq7ewbwXeAQ0KusGZnZd4C7gWuBNGA4sDrc1gKYCvwKaA7kAM9Xkm06cBWwpYy2vcDjwM8r+4BVWPYY4Lzw5+oJnAP8sET7M8BH4feeCtxoZiPDbaOBUcBQoA3QGHig+I3ufqK7Nwn/jNOA9cA/K8ssMczdddMt4jdgLfDtEs/vAd4MP54OPFDJ+68Bppd4PgO4vpxpxwAzSjxPBfYR+mdRWc6NwGnltH0bWFvJ+ytcdjj3mBLt1wMzSzwvAE4o8fyfwB3hxy8CPy/RNgTYD6SUkeNUYA+QGvTvXrfgbtpCl1pnZu2As4CVZpYKDAZeqsb744FsINPMVoa7JiaYWePwJCcCC4qnd/e9wKrw67WtsmV/rT38uGSu+4DRZpZoZt0I/WzeCbdZ+EaJ542ALmXkuBp4Mbx8aaACLehm9riZbTWzxVWYtn24f3KemS00s7PrIqPUyCtmthvYAGwFfgM0I/R3d6SrI9yvvDPcN/6/ZcynFZAIXAScwn+7cIqnbQLsKvWeXYS6IWpbZcsu3b4LaFKiH/0NQp9rH7AMeMzd54Tb3gJuMLOOZpYO/CL8ekrJhZlZSngeT9b400i9FvQW+pOE+k6r4n+BF9y9D3AZ8FBthZKIOc/d04DTgO5ACyAfKAJaF0/k7rd5qB/9ZSChjPnsC98/4O5fuPs24C9A8T/1PUDTUu9pCuwObwgc2XEYmY/1NeUuu5z2psAed3czaw5MA34HJANZwJlm9qPwtI8DzxLa37AEeD/8+sZSy7sA2AF8WNMPI/VboAXd3T8i9Id4hJkdb2bTzCw3vPe/e/Hk/HfFSAc212FUqQF3/5DQP+8/h7sEZhEqQlV9fz6hIlbe0KBLKLEzNdytczywxN3Xe3jHoYd2HkZaucsuqz38uLjtOOCwuz/l7ofcfSPwHOF/VO5e5O6/cfeO7t4u/L5N4VtJVwNPubuGTm3ggt5CL8tE4CZ37wfcyn+3xH8LXGVmG4F/ATcFE0+O0n3Ad8ysN3AbcJ2Z3W5mLeFIP3unCt7/BHCTmbUMH9p4C6HuCght2Z9kZheaWTLwa2Chuy8rb2Zm1ig8LUCSmSUXd4OYWVy4LTH01JLNLKmcWVW27KeAn5pZWzNrA/yM/3aNfB6e/xXhZR4LXEq4z93Mmoc3cMzMTiD0reR37l5U4nO0A0YA/6jgZycNRdB7ZYGOwOLw4yaEvl7PL3FbGm77KfCz8OPBwGdAXND5dSv397qWEke5hF97GHgp/HggoX/MO8O3xcAfgWPC7dfw9aNcEgn9c99JqP/9b0ByifZvE+qD3keoi6JjFfJ5qVvHcNtpZbR9UOK9S4Arq7JsQjsy7yH0TXRH+LGVaP8WMIdQ3/oW4FHCR7EAXYHlhI6EWQf8tIzPcQfwcdC/b92i42buwX5LM7OOwBvuflL4pInl7t66jOmWAN919w3h56uBQe6+tU4Di4hEqajqcnH3r4A1ZnYxHDlTrrj/cT1wevj1HoR2IuUFElREJAoFuoVuZs8S+nrbAviS0GFt7xH6at6a0Nfs59z9d+E+xEcJdcs4cJu7/zuI3CIi0SjwLhcREYmMqOpyERGRo1fWSRx1okWLFt6xY8egFi8iUi/l5uZuc/fMstoCK+gdO3YkJycnqMWLiNRLZrauvDZ1uYiIxAgVdBGRGKGCLiISI6rUh26hy3DtBg4Dh9w9u1R7OjAZaB+e55/d/YnIRhURkYpUZ6foCA8NW1qWccBn7v59M8sElpvZFHcvrHlEERGpikh1uTiQFh6trgmhQYgORWjeIiJSBVUt6A78OzxG+Zgy2icAPQiNUb4IuNlLDPFZzMzGmFmOmeXk5WkYFhGRSKpqQR/q7n0JXRdynJkNL9V+JqGhbtsQujzYhPDIiV/j7hPdPdvdszMzyzwuvlJbdu3nzn8tZcOOgqN6v4hIrKpSQXf3zeH7rYQG9B9QapJrgakeshJYQ+iSYxE3e+0OJk1fw/A/vc91T87h/eVbKSrSeDQiIpUWdDNLNbO04sfAGYQuRlBSyaFtWwHdgNWRjRoyslcbpv9iBONHdGbhxl1c+8QcRtz7AY9+tJqdBdoHKyINV6WjLZrZcYS2yiF0VMwz7v5HMxsL4O6PhC+t9SShIW8NuMvdJ1c03+zsbK/pqf+Fh4qYtmQLT3+6ljlr82mUEMe5vdswenBHTmqbXqN5i4hEIzPLLX3o+JG2oIbPjURBL+mzzV/x9Mx1vDJvE/sOHqZP+wxGD+7A2Se3plFCfMSWIyISpAZR0Ivt2neQl3I3MnnmOlZv28sxqUlc2j+LKwd1oG1G44gvT0SkLjWogl6sqMj5ZNU2nvp0He8u/RKA03u0YvTgDgzr3ILwBd5FROqVigp6YMPn1ra4OOOULpmc0iWTjfkFPDNrPc/P2cB/PvuS41qkctWgDlzYrx3pjRODjioiEhExu4VelgOHDvOvRV/w1KfrmLd+J40T4zmvT1tGD+5Aj9bfOGxeRCTqNMgul8os3rSLpz5dy6vzN3PgUBH9OzbjqkEdOOuk1iQlaBBKEYlOKugV2FlQyIu5G3l65jrWbS+gRZMkLuvfnisGtqeNdqKKSJRRQa+CoiLn45XbePrTtby7bCsGfLtHK0YP7siQ448hLk47UUUkeA1yp2h1xcUZp3bN5NSumWzYUcCzs0M7Uf8d3ol65aAOXKSdqCISxbSFXoEDhw7z1qItPPXpWuau30lyYhzn9W7LqMEdOLGNzkQVkbqnLpcIWLxpF5NnruOV+ZvYf7CIvu0zGKUzUUWkjqmgR1DpM1Gbh89EvWJAe7KapwQdT0RinAp6LSgqcmas2s5Tn67lnaVf4sDp3Vty1aAODO+SqZ2oIlIrtFO0FsTFGcO6tGBYlxZs3rmPZ2ev59nZG3hn6Rw6HJPCT7/TlXN7tw06pog0IDqDJgLaZDTmZ2d0Y8bt3+Jvl/chvXEiNz83nxdzNwYdTUQaEBX0CEpKiGNkrza88MPBDOvcgtteXMC/Fn0RdCwRaSBU0GtBcmI8E0f3o2/7Zvz42Xm8t+zLoCOJSAOggl5LUpISePza/vRo3ZSxk+cyY+W2oCOJSIyrUkE3s7VmtsjM5ptZmYemmNlp4fYlZvZhZGPWT02TE3nqugF0OiaVG57KIXddftCRRCSGVWcLfYS79y7rcBkzywAeAka6+4nAxRHKV+81S03i6RsG0DKtEdc8MZvFm3YFHUlEYlSkulyuAKa6+3oAd98aofnGhJZpyUz5wSCaJicy+vHZrPhyd9CRRCQGVbWgO/BvM8s1szFltHcFmpnZB+FpRpc1EzMbY2Y5ZpaTl5d3tJnrpbYZjZlyw0Di44wrJ81i3fa9QUcSkRhT1YI+1N37AmcB48xseKn2BKAf8D3gTOBXZta19EzcfaK7Z7t7dmZmZk1y10sdW6Qy5YaBHDxcxBWPzmLzzn1BRxKRGFKlgu7um8P3W4GXgQGlJtkITHP3ve6+DfgI6BXJoLGia6s0nr5+IF/tO8iVk2axdff+oCOJSIyotKCbWaqZpRU/Bs4AFpea7FXgFDNLMLMUYCCwNNJhY8VJbdN58rr+bNm1n1GTZpO/tzDoSCISA6qyhd4KmG5mC4DZwJvuPs3MxprZWAB3XwpMAxaGp5nk7qWLvpTQr0NzJl2dzZrte7n6idns3n8w6EgiUs9ptMWAvfPZl4ydnEuf9hn847oBpCRpvDQRKV9Foy3qTNGAffuEVvz10t7krsvnh0/ncuDQ4aAjiUg9pYIeBb7fqw13XdiTj1dsY9yUeRw8XBR0JBGph1TQo8Ql2Vn838gTeWfpl/z0hQUcLgqmK0xE6i912EaRq4d0pKDwMHdPW0bjxDjuuqCnrnwkIlWmgh5lbjzteAoKD/HAeytJSUrgN98/ATMVdRGpnAp6FPrpd7qy98BhHv9kDamN4vn5md2DjiQi9YAKehQyM351Tg8KCg/x4PurSElKYNyIzkHHEpEop4IepcyMP55/MvsOHuZPby/HDK4c0IH0lMSgo4lIlFJBj2LxccafL+7FvsLD3DNtOfdMW85xman0zsqgT/tm9MnKoNuxaSTG62AlEVFBj3qJ8XE8fFU/Zq3ezrwNO5m3ficffZ7H1LmbAEhOjKNn2wx6t8+gT1bovnV644BTi0gQdOp/PeTubMzfFy7w+czfsJMlm76iMHxC0rFNk8Nb8Rn0zsrg5HbpGlJAJEZUdOq/1vJ6yMzIap5CVvMURvZqA8CBQ4dZ+sXuIwV+3vqdTFuyBQh13XQ/Nu1IV03vrAyOa5GqY9xFYowKeoxolBBP76zQFnmx7XsOMH/DziMF/rX5m5kyaz0AaY0SaJWeTPOUJDJSEmmemkRGShLNUxNplpIUuqUm0Szc1jQ5Uf8ARKKcCnoMO6ZJI07v0YrTe7QCoKjIWZW3h3nrd7J48y627TnAjr2FrN9RwPwNO8kvKOTg4bK74OIMMoqLf4liH7pPonlKEqd0baH+e5EAqaA3IHFxRpdWaXRplcYlZH2j3d3ZW3iY/L2F5BcUsiN8n7/34JHnOwsOsmNvIRt2FLBwY6ituO8+IyWRh67oy5DOLer6o4kIKuhSgpnRpFECTRolkNU8pUrvcXcKCg+zZttefvL8fEY9Pptfn3MCowd30JAFInVMBzBLjZgZqY0SOKltOlN/NIQR3TL5zWtLuGPqIgoPaRhgkbpUpYJuZmvNbJGZzTezco81NLP+ZnbYzC6KXESpL9KSE5k4KptxI47nuTkbuHLSTLbtORB0LJEGozpb6CPcvXd5xz+aWTxwN/B2RJJJvRQXZ/z8zO787fI+LNq0i5EPTGfxpl1BxxJpECLZ5XIT8BKwNYLzlHpqZK82vDh2CA5c9MgM3li4OehIIjGvqgXdgX+bWa6ZjSndaGZtgfOBRyqaiZmNMbMcM8vJy8urflqpV05qm85r44dxYpt0xj8zjz+/vZwiXYlJpNZUtaAPdfe+wFnAODMbXqr9PuAX7l7hFY7dfaK7Z7t7dmZmZvXTSr2TmdaIZ34wkEuzs5jw/krGPJ3L7v0Hg44lEpOqVNDdfXP4fivwMjCg1CTZwHNmtha4CHjIzM6LXEypzxolxHPXhSfz2++fwPvLt3LBQzNYt31v0LFEYk6lBd3MUs0srfgxcAawuOQ07t7J3Tu6e0fgReBH7v5K5ONKfWVmXDO0E09dN4Ctuw8wcsInfLJyW9CxRGJKVbbQWwHTzWwBMBt4092nmdlYMxtbu/Ek1gzt3ILXxg+lZVojRj8+myc+WUNQI36KxBoNnyuB2L3/ID95fj7vLN3KpdlZ/O68E2mUEB90LJGoV9HwuTpTVAJRfBLS+BGdeT5nA1c8Oou83ToJSaQmVNAlMHFxxq1ndmPCFX1YsnkXIyfoJCSRmlBBl8Cd0zN0EpIROgnp9QU6CUnkaKigS1Q4qW06r44fxklt0rnp2Xn86e1lOglJpJo0fK5EjdBJSIP49auLefD9VcxcvYNvdW9Jvw7N6NUug8ZJ2mkqUhEVdIkqSQlx3HnByZzUNp0nPlnDn95eDkBCnHFim6b069Ccfh2akd2xGa2aJgecViS66LBFiWo79hYyb30+OevyyV2Xz4INOzkQHme9XbPGoeLeoRl9OzSj+7FNidd1TyXGVXTYorbQJao1T0362nVRCw8V8dkXX5Gzdgdz1+fz6artvDo/tBM1NSmePu2b0a9D6NanfQZpyYlBxhepUyroUq8kJcTROyuD3lkZQOgSeBvz95Eb3oLPWZfPA++toMjBDLq1SiO7YzOyOzSnf6fmtM3QRawldqnLRWLO7v0HWbBhFznrdpC7Lp9563ey58AhAMYMP45bz+hGUoIO8JL6SV0u0qCkJScyrEsLhnVpAcDhIufzL3fz9Mx1TPxoNZ+u2s79l/XmuMwmAScViSxtpkjMi48zerRuyv87/2T+PqofG/ILOOeB6byQs0EDg0lMUUGXBuXME4/lrZtPoWe7dG57cSE3PTuPXft0wQ2JDSro0uC0Tm/MlBsG8fMzu/HW4i2cff/H5K7bEXQskRpTQZcGKT7OGDeiMy+OHUxcHFzy95nc/84KDmu4AanHVNClQevTvhn/+vEpfL9na/76zudcPnEmm3buCzqWyFFRQZcGLy05kfsu68NfLunFks27OOu+j/jXoi+CjiVSbVUq6Ga21swWmdl8M/vGweNmdqWZLQzfZphZr8hHFaldF/Rtx79uPoVOmU340ZS53P7SQgoKDwUdS6TKqrOFPsLde5dzQPsa4FR37wn8HpgYkXQidazDMam8OHYwN552PM/nbOD7D0xnyWZddEPqh4h0ubj7DHfPDz+dCbSLxHxFgpAYH8cvvtudydcPZPf+Q5z/4Awmfbxa47NL1KtqQXfg32aWa2ZjKpn2euCtshrMbIyZ5ZhZTl5eXnVyitS5oZ1bMO2W4Qzvmskf3lzKtU/O0XVPJapVaSwXM2vj7pvNrCXwH+Amd/+ojOlGAA8Bw9x9e0Xz1FguUl+4O5NnruMPby4lLTmBP1/ci9O6tQw6ljRQFY3lUqUtdHffHL7fCrwMDChjIT2BScC5lRVzkfrEzBg1uCOvjR9G89QkrnliDr9/4zMOHDocdDSRr6m0oJtZqpmlFT8GzgAWl5qmPTAVGOXun9dGUJGgdTs2jdfGD2P04A48Nn0N5z84gzXb9gYdS+SIqmyhtwKmm9kCYDbwprtPM7OxZjY2PM2vgWOAh8o7tFEkFiQnxvO7c0/i0dHZbN61j3MnTOeTlduCjiUCaDx0kaO2YUcB1/9jDqvy9vLbkScyalCHoCNJA1DjPnQR+aas5im8dOMQTu2aya9eWcyvX13MocNFQceSBkwFXaQG0pITeXR0Nj84pRNPfbqOa56Yw64CDccrwVBBF6mh+Djjl987gXsu7MmsNds5/6FPWJ23J+hY0gCpoItEyCX9s5h8/UB27jvIeQ9+op2lUudU0EUiaOBxx/DquKEcm57M6Mdn8/Sna4OOJA2ICrpIhH1tZ+mrS7SzVOqMCrpILdDOUgmCCrpILTmys/Qi7SyVuqGCLlLLLsnOYsoNg47sLJ2+QjtLpXaooIvUgQGdmh/ZWXr1E9pZKrVDBV2kjmhnqdQ2FXSROlS8s3TM8OO0s1QiTgVdpI7Fxxn/c3YP7SyViFNBFwmIdpZKpKmgiwSoeGdp6/TGXP3EbP7+4SoKD6lfXY6OCrpIwLKap/DijYP5VveW3PnWMs7464e8tegLgrpWgdRfKugiUSAtOZGJo/rxxDX9SYyP48Ypc7nokU/JXZcfdDSpR6pU0M1srZktKu/ychbyNzNbaWYLzaxv5KOKxDYzY0T3lrx18yncecHJrN9RwIUPz+BHU3JZq2uXShUkVGPaEe5e3l6bs4Au4dtA4OHwvYhUU0J8HJcPaM/IXm149OPV/P3D1fznsy+5alAHfvytLjRLTQo6okSpSHW5nAs85SEzgQwzax2heYs0SKmNErjl21358OencVG/dvxjxlqG/+l9HvlwFfsPHg46nkShqhZ0B/5tZrlmNqaM9rbAhhLPN4Zf+xozG2NmOWaWk5eXV/20Ig1Qy6bJ3HlBT6bdMpzsDs24661lnH7vh7wybxNFRdpxKv9V1YI+1N37EupaGWdmw0u1Wxnv+cZfmrtPdPdsd8/OzMysZlSRhq1rqzSeuHYAz9wwkIyURG55fj4jH5zOjFU6fl1CqlTQ3X1z+H4r8DIwoNQkG4GsEs/bAZsjEVBEvm5I5xa8Pn4Yf7mkFzv2FHLFo7O47sk5rPhyd9DRJGCVFnQzSzWztOLHwBnA4lKTvQaMDh/tMgjY5e5fRDytiAAQF2dc0Lcd7916Gr/4bnfmrNnBmfd9xB1TF7F19/6ILuvg4SK+2LWPhRt3MnP1dg0oFsWqcpRLK+BlMyue/hl3n2ZmYwHc/RHgX8DZwEqgALi2duKKSEnJifHceNrxXNo/i7+9u4LJM9fx6vxNjBl+HGOGH0dKUtmruLvz1f5D5O3ez9bdB8grdTvy2p4D7Nhb+LX3XtY/i7su7FkXH0+qyYI6Gy07O9tzcr5xSLuI1MCabXu5Z9oy3lq8hZZpjbh6SEcOHXa27t5/pEBv/Sp0X9YQA0kJcWQ2aUTLpo3IbNKIzLRGtExLJjMt9HjGqm088cla7rmwJ5f0zyojgdQ2M8t19+wy21TQRWJP7rod/PHNpcxdvxOA5qlJJQp0oyMFuvgWei2ZpskJhL+Nl+lwkTP68VnMWZvP1BuHcFLb9Dr6RFJMBV2kAXJ3tu0pJL1xIkkJkRvlY/ueA5zzwHQS4o03xp9CekpixOYtlauooGssF5EYZWZkpjWKaDEHOKZJIx68si9bdu3nJy/M17HwUUQFXUSqrW/7ZvzqnBN4b9lWHvpgZdBxJEwFXUSOyqhBHTivdxvu/c/nfLxCZ35HAxV0ETkqZsb/u+BkurRsws3PzWfzzn1BR2rwVNBF5KilJCXwyFX9KDxUxI1T5nLgkAYNC5IKuojUyHGZTfjzxT1ZsGEnf3xzadBxGjQVdBGpse+e1Joxw4/jqU/X8cq8TUHHabBU0EUkIm47sxsDOjXn9qkLWbblq6DjNEgq6CISEQnxcUy4og9pyYncOHkuu/cfDDpSg6OCLiIR0zItmQev6Mv6HQX8/J8LCepM9IZKBV1EImpAp+bccVZ3pi3ZwqMfrw46ToOigi4iEXf9sE6cffKx3D1tOTNXbw86ToOhgi4iEWdm3H1hTzock8L4Z+bx5VeRveiGlE0FXURqRVpyIo9c1Y+9Bw4x/pm5HNSVjmqdCrqI1JqurdK468KTmbM2n7vfWhZ0nJhX5YJuZvFmNs/M3iijLd3MXjezBWa2xMx0CToRAeDc3m25ZkhHJk1fw5sLdanh2lSdLfSbgfLO6x0HfObuvYDTgHvNLKmG2UQkRvzP2T3o2z6D215cwMqte4KOE7OqVNDNrB3wPWBSOZM4kGaha1c1AXYAhyKSUETqvaSEOB68sm/ootaTc9l7QOWhNlR1C/0+4DagvL0aE4AewGZgEXCzu39jWjMbY2Y5ZpaTl6fxk0UaktbpjXng8j6sytvD7VMX6aSjWlBpQTezc4Ct7p5bwWRnAvOBNkBvYIKZNS09kbtPdPdsd8/OzMw8usQiUm8N6dyCW8/sxusLNvOPGWuDjhNzqrKFPhQYaWZrgeeAb5nZ5FLTXAtM9ZCVwBqge0STikhMGDv8eL7doxV/eHMpuevyg44TUyot6O5+h7u3c/eOwGXAe+5+VanJ1gOnA5hZK6AboHN+ReQb4uKMey/pRdtmjRk3ZS7b9hwIOlLMOOrj0M1srJmNDT/9PTDEzBYB7wK/cPdtkQgoIrEnvXEiD1/Zj/yCQkY9NpuN+QVBR4oJFtSOiezsbM/JyQlk2SISHT78PI/xz8wlKT6Oh6/qx4BOzYOOFPXMLNfds8tq05miIhKYU7tm8sq4oaQ3TuTKSTN5dvb6oCPVayroIhKo4zOb8PK4oQw5vgV3TF3Er19drHFfjpIKuogELr1xIo9f0//IdUlHPTaLHXsLg45V76igi0hUiI8z/ufsHvzlkl7MXb+TkROm69qk1aSCLiJR5YK+7Xjhh4MpPFTEBQ/NYNriLUFHqjdU0EUk6vTOyuD1m4bRpVUaYyfncv87Kygq0lABlVFBF5Go1KppMs+PGcQFfdry13c+Z9wzcyko1KBeFVFBF5GolZwYz72X9OKXZ/fg7SVbuPDhT3USUgVU0EUkqpkZPxh+HI9f05+N+QWMnPAJs3Th6TKpoItIvXBat5a8Mm4oGSmJXDlpFlNmrQs6UtRRQReReuP4zCa8/KOhDO3cgl++vJj/fWWRTkIqQQVdROqV4pOQfjj8OCbPXK+TkEpQQReReic+zrjj7B789dL/noS09AudhKSCLiL11vl9QichHTxcxIUPz2Da4i+CjhQoFXQRqdd6Z2Xw2vjik5Dm8sC7Kxrs9UpV0EWk3is+Cen8Pm259z+f8/CHq4KOFIiEoAOIiERCcmI8917ci8NFzj3TltMsJYnLB7QPOladqvIWupnFm9k8M3ujnPbTzGy+mS0xsw8jF1FEpGri4ow/X9yLU7tm8suXFzW4PvXqdLncDCwtq8HMMoCHgJHufiJwcc2jiYhUX1JCHA9f1ZfeWRn8+Nn5zFjZcC5vXKWCbmbtgO8Bk8qZ5ApgqruvB3D3rZGJJyJSfSlJCTx+TX86tkjhB0/lsHDjzqAj1YmqbqHfB9wGlHdKVlegmZl9YGa5Zja6rInMbIyZ5ZhZTl5eXvXTiohUUUZKEk9dN5CMlCSueWIOq/L2BB2p1lVa0M3sHGCru+dWMFkC0I/QVvyZwK/MrGvpidx9ortnu3t2Zmbm0WYWEamSY9OTmXzDQAwY/dhsvti1L+hItaoqW+hDgZFmthZ4DviWmU0uNc1GYJq773X3bcBHQK+IJhUROQqdWqTyj+sGsGvfQUY/Npv8GB4moNKC7u53uHs7d+8IXAa85+5XlZrsVeAUM0swsxRgIOXsQBURqWsntU3n0dHZrNtRwLVPzmHvgdi8UMZRn1hkZmPNbCyAuy8FpgELgdnAJHdfHJmIIiI1N/j4Y3jg8j4s3LiTsZNzKTwUe6M0WlCnyGZnZ3tOTk4gyxaRhuuFORu47aWFnNOzNfdf1of4OAs6UrWYWa67Z5fVpjNFRaRBuaR/FjsKCrnrrWU0S0nid+eeiFn9KurlUUEXkQZn7KnHk7+3kL9/tJrmqUn85DvfOCivXlJBF5EG6fazurNjbyH3v7uCZimJXDO0U9CRakwFXUQaJDPjzgtOZue+g/z29c9olprEub3bBh2rRjR8rog0WAnxcTxweR8GdmrOz15YwAfL6/eoJSroItKgJSfG8+jV2XRtlcbYybnkrssPOtJRU0EXkQavaXIi/7huAMc2Tea6J+ewfMvuoCMdFRV0EREgM60RT18/kEYJcYx+fBYbdhQEHanaVNBFRMKymqfw9PUD2Vd4mFGPzWLbngNBR6oWFXQRkRK6HZvGE9f2Z8tX+7n68dns3n8w6EhVpoIuIlJKvw7Nefiqfizfspsb/pHDgUOHg45UJSroIiJlGNGtJfde0otZa3bw+zc+CzpOlaigi4iU49zebfnh8OOYPHM9r87fFHScSqmgi4hU4NYzu9G/YzPumLqIlVuj+3BGFXQRkQokxsfxwOV9aZwYz42T51JQGL0Xx1BBFxGpxLHpydx/WR9W5u3hly8vJqjrSFRGBV1EpAqGdWnBT77dlZfnbeLZ2RuCjlOmKhd0M4s3s3lm9kYF0/Q3s8NmdlFk4omIRI/xIzozvGsmv319CYs37Qo6zjdUZwv9Ziq48LOZxQN3A2/XNJSISDSKizPuu7Q3x6Qm8aMpc9m1L7pOOqpSQTezdsD3gEkVTHYT8BJQv8efFBGpQPPUJCZc0ZfNO/fx838uiKr+9Kpuod8H3AaUeZlsM2sLnA88UtFMzGyMmeWYWU5eXl51coqIRI1+HZpx+1nd+fdnX/LY9DVBxzmi0oJuZucAW909t4LJ7gN+4e4Vnh/r7hPdPdvdszMzM6uXVEQkilw/rBPfPfFY7nxrGTlrdwQdB6jaFvpQYKSZrQWeA75lZpNLTZMNPBee5iLgITM7L4I5RUSiiplxz8U9adesMeOfmcf2KBiZsdKC7u53uHs7d+8IXAa85+5XlZqmk7t3DE/zIvAjd3+lFvKKiESNpsmJPHRlX3YUFHLL8/M5XBRsf/pRH4duZmPNbGwkw4iI1DcntknndyNP5OMV23jgvRWBZkmozsTu/gHwQfhxmTtA3f2amoYSEalPLu2fxey1O7j/3RX069CMU7oEs49QZ4qKiNSQmfGH806iS8sm3PLcfLbs2h9IDhV0EZEISElK4KEr+7H/4GHGPzOXg4fLPMq7Vqmgi4hESOeWTbjzwp7krMvnnmnL6nz5KugiIhE0slcbRg3qwKMfr+HtJVvqdNkq6CIiEfa/5/SgZ7t0bv3nAtZvL6iz5aqgi4hEWKOEeB68oi9xZtw4JZf9B+vmItMq6CIitSCreQp/uaQXSzZ/xe/q6CLTKugiIrXk9B6tGHvq8Twzaz2vzKv9i0yroIuI1KJbz+jKgE7NuWPqIlZ8WbsXmVZBFxGpRQnxcUy4vA+pjeK5ccpc9h6ovYtMq6CLiNSylk2T+dtlfVidt4f/eXlRrV0UQwVdRKQODOkcusj0q/M3M2XW+lpZRrUG5xIRkaM3bkRnPt+6h8y0RrUyfxV0EZE6EhdnPHB5n9qbf63NWURE6pQKuohIjFBBFxGJEVUu6GYWb2bzzOyNMtquNLOF4dsMM+sV2ZgiIlKZ6uwUvRlYCjQto20NcKq755vZWcBEYGAE8omISBVVaQvdzNoB3wMmldXu7jPcPT/8dCbQLjLxRESkqqra5XIfcBtQlWsqXQ+8VVaDmY0xsxwzy8nLy6viokVEpCoqLehmdg6w1d1zqzDtCEIF/Rdltbv7RHfPdvfszMxgrootIhKrrLIxBczsTmAUcAhIJtSHPtXdryo1XU/gZeAsd/+80gWb5QHrjjJ3C2DbUb63rihjzUV7Poj+jNGeD6I/Y7Tl6+DuZW4RV1rQvzax2WnAre5+TqnX2wPvAaPdfcbR56xyjhx3z67t5dSEMtZctOeD6M8Y7fkg+jNGe76SjvrUfzMbC+DujwC/Bo4BHjIzgEP15QcgIhIrqlXQ3f0D4IPw40dKvH4DcEMkg4mISPXU1zNFJwYdoAqUseaiPR9Ef8ZozwfRnzHa8x1RrT50ERGJXvV1C11EREpRQRcRiRFRUdDNLMvM3jezpWa2xMxuDr/e3Mz+Y2YrwvfNSrznDjNbaWbLzezMMub5mpktjsaMZpZkZhPN7HMzW2ZmF0ZhxsvNbFF4wLVpZtairvOZ2THh6feY2YRS8+oXzrfSzP5m4cOroiWjmaWY2Zvh3+8SM7srmvKVmmeg60olv+eIrysRzhfx9aRG3D3wG9Aa6Bt+nAZ8DpwA3APcHn79duDu8OMTgAVAI6ATsAqILzG/C4BngMXRmBH4P+AP4cdxQItoykjo6KetxbnC7/9tAPlSgWHAWGBCqXnNBgYDRmioibMC+hmWmRFIAUaEHycBH0ciYyR/hlG0rlT0e474uhLB33GtrCc1+mxBLryCH/irwHeA5UDrEr+E5eHHdwB3lJj+bWBw+HETYHr4FxSxP9IIZ9wApEbrzxFIBPKADoQK5iPAmLrOV2K6a0qtSK2BZSWeXw78PYifYXkZy5jP/cAPoilftKwrlWSs9XWlBn+HdbKeVOcWFV0uJZlZR6APMAto5e5fAITvW4Yna0voF11sY/g1gN8D9wIF0ZjRzDKKc5rZXDP7p5m1iqaM7n4QuBFYBGwmtMI/FkC+8rQNZ/1a7kjmi0DGkvPJAL4PvBtl+aJlXSnvvRnFOWtrXalJvrpYT6orqgq6mTUBXgJucfevKpq0jNfczHoDnd395drIBzXPSOhrWjvgE3fvC3wK/DmaMppZIqE/1D5AG2Ahoa35us5X7izKeC2ix99GIGPxfBKAZ4G/ufvqaMkXZetKeWp1XYnAz7BW15OjETUFPfzDeQmY4u5Twy9/aWatw+2tCfVXQWiLLKvE29sR+g85GOhnZmsJfZXsamYfRFnG7YS2iIpXpH8CfaMsY28Ad1/loe+WLwBDAshXno18fcz94twREaGMxSYCK9z9vijLF03rSnlqbV2JUL7eUDvrydGKioJuZkboq8pSd/9LiabXgKvDj68m1NdV/PplZtbIzDoBXYDZ7v6wu7dx946EdmJ87u6nRVlGB14HinOdDnwWTRmBTcAJZlY8ott3CF2tqq7zlSn8dXi3mQ0Kz3N0Ze+p64zhef0BSAduiUS2SOaLsnWlvIy1sq5E8HdcK+tJjQTZgV98I/QH5YS+sswP384mNODXu8CK8H3zEu/5JaGjMpZTxtEDQEciu+c+YhkJ7UT5KDyvd4H2UZhxLKE/zoWEVqpjAsq3FtgB7CG0ZX5C+PVsYHE4+wTCZz1HS0ZC3xo8/DMsns8N0ZIvCteV8n7PEV9XIpwv4utJTW469V9EJEZERZeLiIjUnAq6iEiMUEEXEYkRKugiIjFCBV1EJEaooIuIxAgVdBGRGPH/AaOVpzc7TulSAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAEICAYAAABPgw/pAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAArL0lEQVR4nO3deXxU9b3/8dcnOyEhYQlhSSAqoAKyRpBNsXWp1bprFQFFlKLW6u2i9bb13m63V237s4qoiBsorqBYtWivigiyJbLvyBKWAmEJSwKEhO/vjzmhMSYkJJOcmcn7+XjMIzPzPXPOO5mcz5z5nnO+x5xziIhI+IvyO4CIiASHCrqISIRQQRcRiRAq6CIiEUIFXUQkQqigi4hECBV0EZEIoYIu9cLMNpnZYTM7ZGY7zOwlM0sq155tZu+b2T4zKzCzlWb2RzNr7rXfZmazK8zzJjNbZWaFZva1mQ0p1/ZdM1ttZkVm9pmZdTxJtjgze9vL6MxsaIX2C7157DezTTX4XatctgU8YmZ7vNujZmbl2nuZ2Rfesraa2cMVXvsrM8szswNm9rqZNSvXvsL7+5bdSszs79Xllcilgi716QfOuSSgF9AbeAjAzAYCM4E5wFnOuVTge0AJ0LOyGZnZxcAjwCggGTgf2OC1tQKmAb8BWgA5wBvVZJsNDAd2VNJWCLwA/KK6X7AGyx4DXO39Xj2AK4AflWufAszyXnsBcJeZXem1jQRGAIOAdkAT4MmyFzrnujnnkry/cTKQB7xVXWaJYM453XQL+g3YBFxU7vGjwAfe/dnAk9W8/jZgdrnHXwKjq5h2DPBlucdNgcMEPiyqy7kVGFpF20XApmpef9Jle7nHlGsfDcwr97gI6Fru8VvAQ979t4FflGsbCBwBEivJcQFwCGjq93uvm383baFLvTOzDOAyYL2ZNQUGAFNP4fXRQDaQZmbrva6JcWbWxJukG7CkbHrnXCHwtfd8fatu2d9o9+6Xz/U4MNLMYs3sTAJ/m//z2sy7Ue5xPNC5khy3Am97y5dGyteCbmYvmNkuM1teg2k7eP2Ti8xsqZl9vyEySp28a2YHgS3ALuC/gOYE/u9OdHV4/coFXt/4ryuZTzoQC1wPDOHfXThl0yYB+yu8Zj+Bboj6Vt2yK7bvB5LK9aO/T+D3OgysBp53zi302v4B3GFmWWaWAjzoPZ9YfmFmlujN46U6/zYS1vzeQn+JQN9pTfwaeNM51xu4CRhfX6EkaK52ziUDQ4GzgFbAPuA40LZsIufcAy7Qj/4OEFPJfA57P590zv3LObcb+CtQ9qF+CGhW4TXNgIPehsCJHYfB+bW+ocplV9HeDDjknHNm1gKYAfwOSAAygUvN7G5v2heA1wjsb1gBfOY9v7XC8q4F9gKf1/WXkfDma0F3zs0i8I94gpmdYWYzzCzX2/t/Vtnk/HvFSAG2N2BUqQPn3OcEPrz/7HUJzCdQhGr6+n0EilhVQ4OuoNzOVK9b5wxghXMuz3k7Dl1g52GwVbnsytq9+2VtpwOlzrlJzrkS59xW4HW8Dyrn3HHn3H8557Kccxne67Z5t/JuBSY55zR0aiPn9xZ6ZSYA9zrn+gI/599b4v8NDDezrcCHwL3+xJNaehy42Mx6AQ8At5vZL82sNZzoZz/tJK9/EbjXzFp7hzbeT6C7AgJb9t3N7DozSwAeBpY651ZXNTMzi/emBYgzs4SybhAzi/LaYgMPLcHM4qqYVXXLngT81Mzam1k74Gf8u2tkrTf/Yd4y2wA/xOtzN7MW3gaOmVlXAt9KfuecO17u98gALgRePsnfThoLv/fKAlnAcu9+EoGv14vL3VZ5bT8FfubdHwCsBKL8zq9ble/rJsod5eI99zQw1bvfn8AHc4F3Ww78EWjptd/GN49yiSXw4V5AoP/9CSChXPtFBPqgDxPoosiqQT5X4ZbltQ2tpG1mudeuAG6pybIJ7Mh8lMA30b3efSvX/h1gIYG+9R3Ac3hHsQBdgDUEjoTZDPy0kt/jIeALv99v3ULjZs75+y3NzLKA951z3b2TJtY459pWMt0K4HvOuS3e4w3Aec65XQ0aWEQkRIVUl4tz7gCw0cxugBNnypX1P+YB3/WeP5vATqR8X4KKiIQgX7fQzew1Al9vWwE7CRzW9imBr+ZtCXzNft059zuvD/E5At0yDnjAOfexH7lFREKR710uIiISHCHV5SIiIrVX2UkcDaJVq1YuKyvLr8WLiISl3Nzc3c65tMrafCvoWVlZ5OTk+LV4EZGwZGabq2pTl4uISIRQQRcRiRA16nKxwFVbDgKlQIlzLrtCewrwCtDBm+efnXMvBjeqiIiczKn0oV/oAqPcVeYeYKVz7gdmlgasMbNXnXPFdY8oIiI1EawuFwcke4MbJREYs6IkSPMWEZEaqGlBd8DH3pC2YyppHwecTWBI22XAfa7ciHBlzGyMmeWYWU5+vs7aFxEJppoW9EHOuT4ELiN2j5mdX6H9UgIjI7YjcDWZceWvTl7GOTfBOZftnMtOS6v0MEoREamlGhV059x27+cuAuM/96swyShgmgtYD2wkcIWaoNux/wh/+nAVW/YW1cfsRUTCVrUF3cyamlly2X3gEgJjV5dXfiTEdOBMYENwowYs2LSXibM3cv5jn3HHywuZtTaf48c1Ho2ISE2OckkH3vEu5hIDTHHOzTCzsQDOuWeA3wMvmdkyAgP6P3iSI2Lq5Mqe7Tg3qzlT5ufx2oI8/m/VAk5r1ZQR53Xk+uwMmiXE1sdiRURCnm+jLWZnZ7u6nvp/tKSUGct38PKXm/gqr4DEuGiu7t2ekQM6clabb3Xhi4iEPTPLrXgu0Im2cC7o5S3bup9Jczfx3pLtHC05Tv/TWnDrwCwu7ppObLROiBWRyNAoCnqZfYXFvJmzhcnzNrN132HSm8VzS/+O3NQvk9bJCdXPQEQkhDWqgl6m9Ljjs9W7mDRvM7PW5hMbbVzWvS23DuxInw7N8fYJiIiElZMVdN+Gz61v0VHGRV3TuahrOhvyDzF53mbeztnKe0u2061dM24dkMWVvdqREBvtd1QRkaCI2C30yhQeLeHdxduY9OVm1uw8SEqTWH54bibD+3ekQ8vEBs0iIlIbjbLL5WSccyzYuJdJczczY8UOjjvHhWe2ZsSAjlzQOY2oKHXHiEhoUkE/iR37jzBl/mamLNjC7kNH6dgykeH9O3JDdgapiXF+xxMR+QYV9BooLjnOjBU7mDx3Ews37SM+JoqrerVj5IAsurdP8TueiAiggn7KVm4/wOR5m3l30TYOHyuld4dURg7oyPfPaUt8jHaiioh/VNBraf/hY0zN3cor8zazYXchLZvG8cNzM7nlvI60T23idzwRaYRU0Ovo+HHHnK93M2nuZj5ZtROA756dzsgBHRncqZWOaReRBtMoj0MPpqgoY0jnNIZ0TmPrviKmzM/jjYVb+OfKnZzeqinDNTCYiIQAbaHX0tGSUj5c9i8mzd3MIg0MJiINRF0u9Wz5tsDAYNMXBwYG65fVgvsv6szATq38jiYiEUYFvYEUFBXzVs5WXp67iZ0HjvDcyGyGntna71giEkFOVtA1rmwQpSbGcef5p/PBT4bQJT2Zsa/kMn/DHr9jiUgjoYJeD1KaxDLp9n5kNE9k9Ms5LNlS4HckEWkEalTQzWyTmS0zs8VmVmk/iZkN9dpXmNnnwY0ZflomxfPK6P40bxrLrS8uYM2Og35HEpEIdypb6Bc653pV1ndjZqnAeOBK51w34IYg5QtrbVISmHLHecTHRDH8+fls3F3odyQRiWDB6nIZBkxzzuUBOOd2BWm+YS+zRSKv3tGf0uOO4RPns73gsN+RRCRC1bSgO+BjM8s1szGVtHcBmpvZTG+akcGLGP46tU5m0u39OHDkGMMnzif/4FG/I4lIBKppQR/knOsDXAbcY2bnV2iPAfoClwOXAr8xsy4VZ2JmY8wsx8xy8vPz65I77HRvn8JLo87lX/uPMOL5+RQUFfsdSUQiTI0KunNuu/dzF/AO0K/CJFuBGc65QufcbmAW0LOS+UxwzmU757LT0tLqljwM9e3YgudGZrMhv5BbX1zIoaMlfkcSkQhSbUE3s6Zmllx2H7gEWF5hsunAEDOLMbNEoD+wKthhI8Hgzq146pY+LN+2nzteXsiRY6V+RxKRCFGTLfR0YLaZLQEWAB8452aY2VgzGwvgnFsFzACWetNMdM5VLPriubhrOn+9sSfzN+7lrldyKS457nckEYkAOvXfR1Pm5/Gf7yzj8nPa8sTNvYnWtUxFpBoaPjdEDevfgaLiEv7wwSoS46J55LoeukC1iNSaCrrP7hhyOgePlPC3T9bRND6G//pBV10wQ0RqRQU9BNx/UWcKj5YwcfZGkuJj+PmlZ/odSUTCkAp6CDAzfnX52RQWlzDus/U0jY/hrqFn+B1LRMKMCnqIMDP+cPU5FB4t5ZEZq0mKj2bEgCy/Y4lIGFFBDyHRUcZfbuxJUXEpv5m+gsS4GK7rm+F3LBEJExoPPcTERkcxblhvBnVqyS/eXsKM5f/yO5KIhAkV9BCUEBvNhBHZ9MpM5d7XFvH52sY17o2I1I4KeohqGh/Di6P60bl1Mj+anKNL2YlItdSHHsJSmsQyeXQ/bnx2Ljc/N48u6cn07pBK78zm9OqQSqe0JJ2IJCIn6NT/MJB/8Civzt/MorwCFm8pYP/hYwAkx8fQIzOF3pnN6d0hlV6ZqbRMivc5rYjUJ536H+bSkuO5/6LA8PLOOTbuLjxR3Bdt2cfTn39N6fHAB3OHFon0ykw9UeC7tmtGfEy0n/FFpIGooIcZM+P0tCROT0s6cUjj4eJSlm/fz6K8fSzKK2Dhpr28t2Q7AHHRUXRr38wr8s3pnZlKRvMmGl5AJAKpyyVC/Wv/YRaXbcXnFbB0WwFHjgWG6W2VFEfPjFTapCTQPDGO5k3jaJ4Y6/389/3k+BgVfpEQoy6XRqhtShPantOEy85pC8Cx0uOs2XGQRVsKWJxXwLJtBSzaUkBBUTHHq/hMj4kyUhPLF/vYb34AJHofAE0D9zu2bKohgEV8pC30Ru74cceBI8fYV3SMfUXF7CssDtwvLA48/sb9wOOComKOlX77/6ZnRgrPjsimTUqCD7+JSOOgLXSpUpS3FZ6aGMdpNK3Ra5xzHDpaQkHRMfZ6xX7T7kIe+2gNV46bzYSRgZOiRKRh6cQiOWVmRnJCLJktEumZmcrQM1tz26DTmHr3QOJjo7jx2bm8s2ir3zFFGp0aFXQz22Rmy8xssZlV2U9iZueaWamZXR+8iBIuzmrTjOn3DKZPh1T+440l/OnDVScOpxSR+ncqW+gXOud6VdV3Y2bRwCPAR0FJJmGpRdM4Jo/uz4jzOvLsrA3c8fJCDhw55ncskUYhmF0u9wJTgV1BnKeEodjoKH5/dXf+cHV3vli3m2uemsPG3YV+xxKJeDUt6A742MxyzWxMxUYzaw9cAzxzspmY2RgzyzGznPx8jSAY6Yaf15HJo/uzt7CYq8bN5ot1es9F6lNNC/og51wf4DLgHjM7v0L748CDzrnSk83EOTfBOZftnMtOS0s79bQSdgac0ZL3fjyYtilNuPWFBbwweyN+HSorEulqVNCdc9u9n7uAd4B+FSbJBl43s03A9cB4M7s6eDElnGW2SGTq3QO56Ox0fvf+Sh6cupSjJSf97BeRWqi2oJtZUzNLLrsPXAIsLz+Nc+4051yWcy4LeBu42zn3bvDjSrhKio/hmeF9+cl3OvFmzlaGPTef/INH/Y4lElFqsoWeDsw2syXAAuAD59wMMxtrZmPrN55Ekqgo46eXnMm4Yb1ZsX0/V46bzfJt+/2OJRIxdOq/+GL5tv2MmZTD3qJi/nxDT67o0c7vSCJh4WSn/utMUfFF9/YpTP/xYLq1S+HHUxbx14/XcFwnIYnUiQq6+CYtOZ4pd/bnhr4ZPPHpesa+kkvh0RK/Y4mELRV08VV8TDSPXt+Dh6/oyv+t2sl1T3/Jlr1FfscSCUsq6OI7M+P2wafx0qh+bC84zJXjZjP36z1+xxIJOyroEjLO75LG9B8PpkXTOEY8P59xn65j9Y4DGuBLpIZ0lIuEnANHjnH/64v5dHVgWKDk+Bh6dUglu2ML+nZsTq8OqSTFayh/aZx0gQsJK80SYnn+1mzy9haRs2kfuXn7+GrzPh7/ZC3OQZQFhurt27E52VnN6dOhuS58LYK20CWM7D98jMVbCsjdtJfcvH0syiugqDgwhEB6s3j6dgwU9+ysFnRt24y4GPUoSuTRFrpEhJQmsVzQJY0LugQGdispPc7qHQf5Km8fuZv3kbNpHx8u2wFAfEwUPTNTA1vxXqFv3jTOz/gi9U5b6BJRduw/wld5+0501azYtp8Sb6fqmenJPPyDrgzq1MrnlCK1d7ItdBV0iWiHi0tZurWA3Lx9vJ27lY27C/nR+Wfws0u6EButLhkJPzr1XxqtJnHR9D+9JXcP7cT79w7mpnMzeebzr7n+6S/ZvEdXUZLIooIujUZiXAx/urYH42/pw8bdhXz/b18w7autfscSCRoVdGl0vn9OW/5x//l0a5fCT99cwv2vL+KgLmQtEUAFXRql9qlNmHJnf/7joi68t2Q7lz8xm0V5+/yOJVInKujSaMVER3HfRZ1580cDKD3uuOGZuTz12XoNNSBhSwVdGr3srBZ8eN8QLu3ehsc+WsPwifPZsf+I37FETlmNCrqZbTKzZWa22My+dayhmd1iZku925dm1jP4UUXqT0qTWMbd3JtHr+vB4i0FXPa3Wfxz5U6/Y4mcklPZQr/QOderiuMfNwIXOOd6AL8HJgQlnUgDMjNuPDeT938ymLYpTbhzUg4PT1/OkWOlfkcTqZGgdLk45750zpXtUZoHZARjviJ+OCMtiXfuGcjowacxae5mrho3h7U7D/odS6RaNS3oDvjYzHLNbEw1044G/lFZg5mNMbMcM8vJz88/lZwiDSo+JprfXNGVl0ady57Co/zgydlMnrcZv86sFqmJGp36b2btnHPbzaw18E/gXufcrEqmuxAYDwx2zp30kjM69V/CRf7Bo/zsrSXMWpvPJV3TeeS6HhroS3xT51P/nXPbvZ+7gHeAfpUspAcwEbiqumIuEk7SkuN56bZz+fXlZ/PZml1c9rcvdIk8CUnVFnQza2pmyWX3gUuA5RWm6QBMA0Y459bWR1ARP0VFGXcMOZ137h5EYlw0wybO47GPVnOs9Ljf0UROqMkWejow28yWAAuAD5xzM8xsrJmN9aZ5GGgJjK/q0EaRSNC9fQp/v3cwN/TN4KnPvmbk8wsoKCr2O5YIoOFzRWptau5WHpq2jHapCUy89Vw6tU7yO5I0Aho+V6QeXNc3g9fG9OfgkRKuGT+HL9bpyC3xlwq6SB307diC6T8eRPvUJtz24kImzd3kdyRpxFTQReooo3kib981kAvPTOPh6Sv4zbvLtbNUfKGCLhIESfExPDsimx9dcDqT521m1IsL2V+kMdalYamgiwRJdJTx0GVn89j1PZi/cQ/XjJ/DhvxDfseSRkQFXSTIbsjOZMqd51Fw+BhXPzWHOet3+x1JGgkVdJF6cG5WC6bfM4g2KQmMfGEBr87f7HckaQRU0EXqSWaLRKbeNZDzO7fiV+8s57/fW0GJdpZKPVJBF6lHyQmxTLz1XO4YfBovfbmJUS8tZP9h7SyV+qGCLlLPoqOMX1/RlUeuO4e5X+/h2vFz2LS70O9YEoFU0EUayA/P7cArd/Rnb2ExV4+foxEbJehU0EUa0Hmnt+TdewbRKimeEc/P5/UFeX5Hkgiigi7SwDq2bMq0uwcysFMrfjltGb/7+0pKj+tKSFJ3KugiPmiWEMsLt2YzalAWL8zZyOiXF3LwiHaWSt2ooIv4JCY6iv/6QTf+eE13Zq/bzbXjv2TzHu0sldpTQRfx2S39OzJpdD92HTzKpY/P4i8fr+HQ0RK/Y0kYUkEXCQEDz2jFBz8ZzCVd2/Dkp+sZ+thnTJ63WSciySmpUUE3s01mtqyqy8tZwBNmtt7MlppZn+BHFYlsGc0TeeLm3ky/ZxCnpyXxm3eXc+njs/jnyp34dWUxCS+nsoV+oXOuVxWXProM6OzdxgBPByOcSGPUMzOVN8acx3Mjs3HAnZNy+OGEeSzZUuB3NAlxwepyuQqY5ALmAalm1jZI8xZpdMyMi7um89H95/P7q7uzIf8QVz01h5+8togte4v8jichqqYF3QEfm1mumY2ppL09sKXc463ec99gZmPMLMfMcvLzdf1FkerERkcx4ryOzPzFhdz7nU58vHIH3/3L5/zxg5W6gIZ8S00L+iDnXB8CXSv3mNn5Fdqtktd8q9PPOTfBOZftnMtOS0s7xagijVdSfAw/u+RMZv78Qq7q1Y6Jszdy/mOfMfGLDRwtKfU7noSIGhV059x27+cu4B2gX4VJtgKZ5R5nANuDEVBE/q1NSgKP3dCTD38yhJ6Zqfzhg1Vc9NfP+fuS7dpxKtUXdDNrambJZfeBS4DlFSZ7DxjpHe1yHrDfOfevoKcVEQDObtuMSbf3Y9Lt/WgaF8O9ry3i6vFfsmDj3npb5pFjpew5dLTe5i91F1ODadKBd8ysbPopzrkZZjYWwDn3DPAh8H1gPVAEjKqfuCJS3vld0hjUqRXTvtrKnz9ew43PzuWSruk8eNlZnJGWVKN5HD/u2FNYzM4DR9h54Ag7Dhxh5/7Azx0HjrLLe67A67N/4HtncvfQTvX5a0ktmV9f07Kzs11OzrcOaReRWjpcXMrzszfw9MyvOVJynGH9OjB26BkUlxxnx/5yxbqscO8/ws4DR9l18AjHSr9ZB6IMWiXF0yYlgfRmCaQ3i6dNswQWbyngk9W7mHR7P4Z01n4wP5hZbhWHj6ugi0Sa3YeO8rf/W8eUBXmVjuKYFB9DerN40psl0KZZAukp3s+ywp2SQFpSPDHR3+6RLSou4eqn5rD7UDHv3zuYdqlNGuJXknJU0EUaofW7DjFzzS6aJ8ad2NJuk5JAUnxNelqr9nX+Ia4aN4dOrZN480cDiIvRCCIN6WQFvW7vrIiErE6tk+jUumb96KfijLQkHru+B3e9+hV//GAlv72qe9CXIbWjj1YROWWXndOWO4ecxstzNzN98Ta/44hHBV1EauWB751Fv6wW/HLqMtbuPOh3HEEFXURqKTY6inHDetM0Poaxk3N1xaUQoIIuIrXWulkCTw3rzea9RTw4danOVvWZCrqI1En/01vy4PfO5MNlO3h+9ka/4zRqKugiUmd3Djmd73Vrw5/+sbpehx+Qk1NBF5E6MzMevaEHHVok8uMpX7Hr4BG/IzVKKugiEhTNEmJ5engfDhw5xr1TFul6qD5QQReRoDmrTTP+dO05zN+4l8c+XuN3nEZHBV1Eguqa3hkMP68Dz36+gRnLd/gdp1FRQReRoPvNFV3pmZHCL95awsbdhX7HaTRU0EUk6OJjohk/vC8x0cZdr+RyuFiXyWsIKugiUi/apzbh8Zt6s2bnQX71zjKddNQAVNBFpN5c0CWN+7/bhWmLtjFlQZ7fcSJejQu6mUWb2SIze7+SthQz+7uZLTGzFWamS9CJCAD3fqcTQ89M47fvrWTJlgK/40S0U9lCvw9YVUXbPcBK51xPYCjwFzOLq2M2EYkAUVHG/7uxF2nJ8dz96lfsKyz2O1LEqlFBN7MM4HJgYhWTOCDZAleSTgL2AiVBSSgiYa950zieHt6H/INHue+NxZVeGk/qrqZb6I8DDwBVnfo1Djgb2A4sA+5zzuk0MRE5oUdGKv99ZTdmrc3nyU/X+R0nIlVb0M3sCmCXcy73JJNdCiwG2gG9gHFm1qySeY0xsxwzy8nPz69dYhEJWzf3y+S6Phn87ZN1zFyzy+84EacmW+iDgCvNbBPwOvAdM3ulwjSjgGkuYD2wETir4oyccxOcc9nOuey0tLQ6RheRcGNm/OHq7pyZnsz9byxm674ivyNFlGoLunPuIedchnMuC7gJ+NQ5N7zCZHnAdwHMLB04E9gQ5KwiEgGaxEXzzPC+lJY67n71K46W6KSjYKn1cehmNtbMxnoPfw8MNLNlwCfAg8653cEIKCKRJ6tVU/5yY0+Wbt3PT99YwpFjKurBYH6dvZWdne1ycnJ8WbaIhIYJs77mfz5cTY+MFCaMyKZNSoLfkUKemeU657Ira9OZoiLimzHnn8GEEX35etchrhw3m0V5+/yOFNZU0EXEV5d0a8O0uwcRHxvFDyfMY2ruVr8jhS0VdBHx3ZltknnvnsH07dCcn721hP/5cJVOPqoFFXQRCQnNm8YxaXQ/Rg7oyIRZG7j9pYXsP3zM71hhRQVdREJGbHQUv7uqO/9zzTnMWb+ba8bPYUP+Ib9jhQ0VdBEJOcP6d+DVO/pTUHSMq56aw+drdWZ5Taigi0hI6n96S6bfM4j2qU0Y9eICJn6xQRfJqIYKuoiErMwWiUy9ayCXdmvDHz5Yxc/fWqqTkE5CBV1EQlrT+BieGtaH+y/qzNSvtnLzc/PYdeCI37FCkgq6iIS8qCjj/ou68PQtfVj9r4NcOW4OS7cW+B0r5Kigi0jYuOyctky9ayDRUcYNz8xl+uJtfkcKKSroIhJWurZrxns/HkTPzFTue30xj85YzXGdhASooItIGGqZFM8ro/tzc78OjJ/5NXdOyuHgEZ2EpIIuImEpLiaK/7mmO7+/qhsz1+Zzzfgv2bS70O9YvlJBF5GwZWaMGJDF5NH92H3oKFc9NYc56xvvpRhU0EUk7A08oxXv3TOYNs0SuO3FBcxqpGeWqqCLSETo0DKRN8cOoFPrZH40OZfczY1vbHUVdBGJGClNYpl0ez/Sm8Uz6sUFrN5xwO9IDarGBd3Mos1skZm9X0X7UDNbbGYrzOzz4EUUEam5tOR4Jo/uT5O4aEY8v4C8PUV+R2owp7KFfh+wqrIGM0sFxgNXOue6ATfUPZqISO1ktkjkldH9OVZ6nFuen8fORjJUQI0KupllAJcDE6uYZBgwzTmXB+Cc2xWceCIitdM5PZmXRvVj76FiRj6/gIKiYr8j1buabqE/DjwAHK+ivQvQ3MxmmlmumY2sbCIzG2NmOWaWk5/fOPdCi0jD6ZWZynMjs9m4u5BRLy2k8GiJ35HqVbUF3cyuAHY553JPMlkM0JfAVvylwG/MrEvFiZxzE5xz2c657LS0tNpmFhGpsYGdWvHksN4s2VLA2FdyOVoSucPv1mQLfRBwpZltAl4HvmNmr1SYZiswwzlX6JzbDcwCegY1qYhILV3arQ2PXNeDL9bt5v7XF0fsBairLejOuYeccxnOuSzgJuBT59zwCpNNB4aYWYyZJQL9qWIHqoiIH27IzuTXl5/NP5bv4D+nLYvIqx/F1PaFZjYWwDn3jHNulZnNAJYS6Gef6JxbHqSMIiJBcceQ09l/+BhPfrqe1MRYHvr+2X5HCqpTKujOuZnATO/+MxXaHgMeC1YwEZH68NOLu1BQdIxnZ20gNTGOu4ae4XekoKn1FrqISDgyM357ZTcOHDnGIzNWk9IklmH9O/gdKyhU0EWk0YmKMv58Q08OHinhV+8uIzkhhh/0bOd3rDrTWC4i0ijFRkfx1LA+nNuxBT99czEz14T/+ZAq6CLSaDWJi2bibdl0bp3M2Fdyydm01+9IdaKCLiKNWrOEWCaN7ke7lCaMemkhK7eH7wiNKugi0ui1Sopn0uh+JMXHMPKFBWF7KTsVdBERIKN5IpNH9+e4cwx/fj479offCI0q6CIink6tk3h5VD8Kio4x4vn57CsMrxEaVdBFRMo5JyOF50Zms3lvEbeF2QiNKugiIhUMOKMlTw3rw/Jt+xkzOSdsRmhUQRcRqcTFXdN57PoezFm/hz9+EB5jDaqgi4hU4do+Gdw55DQmzd3M35ds9ztOtVTQRURO4oHvnUV2x+b8cupSvs4/5Heck1JBFxE5idjoKMYN60NCbDR3vZJLUXHo7iRVQRcRqUablAT+dlNv1u06xK/fXR6yF8dQQRcRqYHBnVtx33c7M+2rbbyxcIvfcSqlgi4iUkP3fqczQzq34uH3VrBi+36/43xLjQu6mUWb2SIze/8k05xrZqVmdn1w4omIhI7oKOPxH/aiRWIcd7/6FQeOHPM70jecyhb6fZzkws9mFg08AnxU11AiIqGqZVI844b1Ztu+w/zirSUh1Z9eo4JuZhnA5cDEk0x2LzAVCP9R4kVETiI7qwW/vOwsPlqxk+dnb/Q7zgk13UJ/HHgAOF5Zo5m1B64Bnqmsvdx0Y8wsx8xy8vPzTyWniEhIGT34NC7tls7//mM1uZtD48IY1RZ0M7sC2OWcyz3JZI8DDzrnTjrggXNugnMu2zmXnZaWdmpJRURCiJnx6PU9aZfahB9PWcSeQ0f9jlSjLfRBwJVmtgl4HfiOmb1SYZps4HVvmuuB8WZ2dRBzioiEnJQmsYy/pQ97Cou5/43FlB73tz+92oLunHvIOZfhnMsCbgI+dc4NrzDNac65LG+at4G7nXPv1kNeEZGQ0r19Cr+9shtfrNvNuE/X+5ql1sehm9lYMxsbzDAiIuHopnMzubZ3ex7/ZC2z1+32LYf5dchNdna2y8nJ8WXZIiLBVlRcwtVPzWHPoWI++MkQ2qQk1MtyzCzXOZddWZvOFBURCYLEuBjG39KHw8dKufe1rzhWWulBgfVKBV1EJEg6tU7mT9eew8JN+3jsozUNvnwVdBGRILqqV3tGnNeRCbM28PGKHQ26bBV0EZEg+/UVZ9MjI4WfvbWEvD1FDbZcFXQRkSCLj4nmqWF9MODuKbkcOdYwF5lWQRcRqQeZLRL56429WL7tAL97f2WDLFMFXUSknlzUNZ2xF5zBlPl5vLtoW70vTwVdRKQe/fySLvQ7rQUPTVvGup0H63VZKugiIvUoJjqKcTf3pml8NHe9+hWFR+vvItMq6CIi9ax1swSeuKk3G/IP8Z/vLKu3i2KooIuINICBnVrxHxd1Yfri7bw6P69elhFTL3MVEZFvuefCTqzddYi05Ph6mb8KuohIA4mKMp68uXf9zb/e5iwiIg1KBV1EJEKooIuIRAgVdBGRCFHjgm5m0Wa2yMzer6TtFjNb6t2+NLOewY0pIiLVOZWjXO4DVgHNKmnbCFzgnNtnZpcBE4D+QcgnIiI1VKMtdDPLAC4HJlbW7pz70jm3z3s4D8gITjwREampmna5PA48ANTkInmjgX9U1mBmY8wsx8xy8vPza7hoERGpiWq7XMzsCmCXcy7XzIZWM+2FBAr64MranXMTCHTHYGb5Zrb5VAN7WgG7a/nahqKMdRfq+SD0M4Z6Pgj9jKGWr2NVDVbdIDFm9idgBFACJBDoQ5/mnBteYboewDvAZc65tXVNXE2mHOdcdn0uo66Use5CPR+EfsZQzwehnzHU85VXbZeLc+4h51yGcy4LuAn4tJJi3gGYBoyo72IuIiKVq/VYLmY2FsA59wzwMNASGG9mACXh8okmIhIpTqmgO+dmAjO9+8+Ue/4O4I5gBqvGhAZcVm0pY92Fej4I/Yyhng9CP2Oo5zuh2j50EREJDzr1X0QkQqigi4hEiJAo6GaWaWafmdkqM1thZvd5z7cws3+a2TrvZ/Nyr3nIzNab2Rozu7SSeb5nZstDMaOZxZnZBDNba2arzey6EMx4s5kt88bnmWFmrRo6n5m19KY/ZGbjKsyrr5dvvZk9Yd7e+FDJaGaJZvaB9/6uMLP/DaV8Febp67pSzfsc9HUlyPmCvp7UiXPO9xvQFujj3U8G1gJdgUeBX3rP/xJ4xLvfFVgCxAOnAV8D0eXmdy0wBVgeihmB3wJ/8O5HAa1CKSOBneW7ynJ5r/9vH/I1JXCS2lhgXIV5LQAGAEbgzOTLfPobVpoRSAQu9O7HAV8EI2Mw/4YhtK6c7H0O+roSxPe4XtaTOv1ufi78JH/w6cDFwBqgbbk3YY13/yHgoXLTfwQM8O4nAbO9Nyho/6RBzrgFaBqqf0cgFsgncEaaAc8AYxo6X7npbquwIrUFVpd7fDPwrB9/w6oyVjKfvwF3hlK+UFlXqslY7+tKHf4PG2Q9OZVbSHS5lGdmWUBvYD6Q7pz7F4D3s7U3WXsCb3SZrd5zAL8H/gIUhWJGM0sty2lmX5nZW2aWHkoZnXPHgLuAZcB2Aiv88z7kq0p7L+s3cgczXxAylp9PKvAD4JMQyxcq60pVr00ty1lf60pd8jXEenKqQqqgm1kSMBW43zl34GSTVvKcM7NeQCfn3Dv1kQ/qnpHA17QMYI5zrg8wF/hzKGU0s1gC/6i9gXbAUgJb8w2dr8pZVPJcUI+/DULGsvnEAK8BTzjnNoRKvhBbV6pSr+tKEP6G9bqe1EbIFHTvjzMVeNU5N817eqeZtfXa2xLor4LAFllmuZdnEPiEHAD0NbNNBL5KdjGzmSGWcQ+BLaKyFektoE+IZewF4Jz72gW+W74JDPQhX1W28s0hmstyB0WQMpaZAKxzzj0eYvlCaV2pSr2tK0HK1wvqZz2prZAo6GZmBL6qrHLO/bVc03vArd79Wwn0dZU9f5OZxZvZaUBnYIFz7mnnXDsXGHdmMLDWOTc0xDI64O9AWa7vAitDKSOwDehqZmnedBcTuLhJQ+erlPd1+KCZnefNc2R1r2nojN68/gCkAPcHI1sw84XYulJVxnpZV4L4HtfLelInfnbgl90I/EM5Al9ZFnu37xMYH+YTYJ33s0W51/yKwFEZa6jk6AEgi+DuuQ9aRgI7UWZ58/oE6BCCGccS+OdcSmClaulTvk3AXuAQgS3zrt7z2cByL/s4vLOeQyUjgW8Nzvsbls3njlDJF4LrSlXvc9DXlSDnC/p6UpebTv0XEYkQIdHlIiIidaeCLiISIVTQRUQihAq6iEiEUEEXEYkQKugiIhFCBV1EJEL8fwzr/nYLoOgmAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -1603,8 +1713,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
-   "id": "c117cf52",
+   "execution_count": 36,
+   "id": "5b585dba",
    "metadata": {},
    "outputs": [
     {
@@ -1613,13 +1723,13 @@
        "Text(0.5, 1.0, 'RGI60-11.01450')"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAEICAYAAABWJCMKAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAsyUlEQVR4nO3deXxU1fnH8c+TDQg7JGGPYUdkEyIqIkIpFVdcflbUIipK7U+ttrZqN7Wltta6a1tFRNBWrFapiFariCKCYkRkh4CsAklYZEeWPL8/5gbH/BISyCQzk3zfr9e85s459955JsnNM/fcc88xd0dERGqehGgHICIi0aEEICJSQykBiIjUUEoAIiI1lBKAiEgNpQQgIlJDKQGIiNRQSgASM8xstZntNbNdZrbJzCaYWb2w+mwzm2pm28zsKzNbbGb3mFnjoP4qM5tZbJ/DzWyJme02s5VmdnpY3WAzW2pme8xsupkdd4TYUszsX0GMbmYDi9UPCvax3cxWl+Ozlvre5d2XmZ0RxPL7sLKBZlYY/AyLHiPD6muZ2Xgz2xH8jH9aVqxSfSkBSKw5z93rAb2AE4FfAJhZP+A94EOgi7s3AoYCB4GeJe3IzIYAfwKuBuoDA4Avgro04BXgN0ATIAf4ZxmxzQR+AGwqoW43MB74eVkfsBzvXea+zCwZeAT4uITqDe5eL+wxMazubqAjcBwwCLjNzIaWFbNUT0nRDkCkJO6+yczeIpQIAO4DnnH3P4atsxa46wi7+S3wO3f/KHj9ZVjdRcAid38JwMzuBjabWRd3X1pCPPuBh4N1D5VQPweYY2bfLcfHO+J7l3NftwL/BTLK8X7hrgSudvdtwDYzewq4CnjzKPcj1YDOACQmmVlr4CxghZnVBU4FXj6K7ROBbCDdzFaY2Xoze9zM6gSrnAB8XrS+u+8GVgblla1C7x00F10D/K6UVTLMLM/MVpnZQ8HPj6CprGX4ewfLVfGZJQbFXQII2i/zzWxhOdYdYGZzzeygmf1PsbqRZpYbPEaWtg+pcv82s53AOiCf0Df8xoT+Vg83vZjZfcF1gN1m9usS9tMMSAb+Bzidb5qUitatB2wvts12Qk1Fla2i7/0o8Bt331VC3VJCn7UF8B2gD/Bg2PsWvdexvK9UM3GXAIAJhNp+y2MtodPb58MLzawJoX8sJwN9gbuKLiRK1F3g7vWBgUAXIA3YBhQS+qcGgLvfFlwHmEzJTZl7g+fH3H2ju28m9I/w7KB8F9Cg2DYNgJ1mlhl+ETUyH+tbSn3vsjY0s/OA+u5e4vUKd9/k7ovdvdDdVwG3EUqCRe9b9F5H9b5SPcVdAnD3GcDW8DIza29mb5rZp2b2gZl1CdZd7e7zCf3zCHcm8La7bw3aQt+m/ElFqoC7v08o2d8fNJF8TKjtvLzbbwPWA6UNd7uIsIvHQTNJe0Jt82vDL6Ie40c4klLfuxzbDgaygx48m4BLgVvM7NVS1nfA4PDPZCPfvmjes5zvK9VQ3CWAUowFbnL3PsDPgL+WsX4rQk0MRdYHZRJbHgaGmFkvQt9krzGzO8wsAw5fJ2h7hO2fAW4ys4zgDO8WYGpQNxnoZmYXm1lt4E5gfkkXgIsEXShrBy9TzKy2mVlQlxDUJYdeWm0zSyllV0d87zL29RugE6Fmnl7AFOApQj2dirqBZlpIG+BeIDw5PAv82swaB1+UriOUaKUGivsEYKF+4v2Al8xsHvAkYU0FpW1WQpkmRogx7l5A6B/Wb9x9JqE27QHAcjP7ilDPlfeAx0rZxRjgE2A5sAT4DLgnbN8XB6+3EWoOHF5GSMsINS21At4Klov67w8IXr8BZAbL/y3a0MwWmdkV5XzvUvfl7juDZp5N7r4pqNvt7kVnxb2B2YS6ks4CFgI/Dtv3XYQuOK8B3gf+7O7qAVRDWTxOCGNmWcBUd+9mZg2AZe5e6j99M5sQrP+v4PVlwEB3/2Hw+kngPXefVOnBi4jEiLg/A3D3HcAqM7sEQufLZlbijUFh3gK+F5wGNwa+F5SJiNQYcZcAzGwSoVPczkHf7lHAFcAoM/uc0AWtYcG6J5nZeuAS4EkzWwQQnC4XNQ98Quhmoa3//91ERKqvuGwCEhGRiou7MwAREYmMuBoLKC0tzbOysqIdhohIXPn00083u3t68fK4SgBZWVnk5OREOwwRkbhiZmtKKlcTkIhIDaUEICJSQykBiIjUUEoAIiI1lBKAiEgNpQQgIlJDlZkAypqBy8yGmdl8M5tnZjlm1j8o7xyUFT12mNktQd3dZvZlWN3ZJe1bREQqT3nuA5gAPE5oWN6STAOmuLubWQ/gRaCLuy8jmNA7mJ/1S0LjoBd5yN3vP8a4j8q0JXksz9tFp2b16JhRn9aN65CQUNKI0CIiNUeZCcDdZwTDL5dWHz5lXl1KHld/MLDS3Uu8GaGyvb+8gGdnf/PWdZIT6ZBRj47N6tGpWX06ZoSeWzVSYhCRmqNcg8GFj79fSv2FwB+BDOAcd59drH48MNfdHw9e301ort4dQA5wazBdXUn7Hg2MBsjMzOyzZs2x5ZDtew+wIn8ny/N2kZu3i9z8nSzP20nejq8Pr5OaEiSGjPpBcggtKzGISDwzs0/dPfv/lUciAYStNwC4092/G1aWAmwATnD3vKCsGbCZ0NnCGKCFu19TVhzZ2dke6aEgtu85QG7+TnLzd7E8bye5eaHn/J0lJ4ZOwVnD8S0a0Lxh7SPsWUQkNpSWACI6FlDQXNTezNLcfXNQfBahb/95YesdXjazp/hmntYq1zA1meysJmRnNflWeVFiWB4khNz8nXyQW8DLc9cfXud/+rTm9qFdSK9fq6rDFhGpsAonADPrQKh9382sN5ACbAlb5TJgUrFtWrj7xuDlhYTmLY0ppSWGr/bsJzd/F+8szmP8h6t4a+Embv5uR0b2yyI5Ub1qRSR+lNkEFMzANRBIA/IITSqdDODuT5jZ7cCVwAFCE1T/PJjAGzNLBdYB7dx9e9g+nyPUQ8iB1cAPwxJCqSqjCagivijYxW9fW8z7ywvomFGP355/Av06pEU7LBGRb6nQNYBYEWsJAMDdeWdJPr+buoh1W/dyTvcW/PKc42nVqE60QxMRAaroGkBNZGYM6dqM0zumMXbGF/xl+greXZrPDYPac+3p7aidnBjtEEVESqRG6wipnZzIjwd35J2fnsEZndK5/7/LOfPhGUxbklf2xiIiUaAEEGFtmqTyxIg+PDeqL0kJxqiJOVwz4RNWb94d7dBERL5FCaCSnN4xnf/cPIBfnX08H3+xhe89NIM/v7WUPfsPRjs0ERFACaBSpSQlcN2Adkz/2UDO6dGCv0xfyeAH3mfq/A3E08V3EamelACqQEaD2jx0aS9euv5UGqemcOPzn3H5Ux+zbNPOaIcmIjWYEkAVOimrCa/d1J8xF3Rj8cYdnP3oB/zutcXs2Hcg2qGJSA2kBFDFEhOMEaccx/SfDeT72W14ZtYqvnP/e7yYs47CQjULiUjVUQKIkiZ1U/jjRd2ZckN/2jRJ5bZ/zeeWf87jkJKAiFQRJYAo6966IS9f349bh3RiyucbuO1f83UmICJVQncCx4CEBOOmwR055M7D7+SSkmTcc0F3zUEgIpVKCSCG3Dy4I/sPFvLX91aSnJjAb88/ATMlARGpHEoAMcTM+PmZnTlwqJCnPlhFcmICvz7neCUBEakUSgAxxsz45dnHc+CQ8/TMVaQkJXDbmZ2VBEQk4pQAYpCZcdd5Xfn6YCF/e28lKYkJ/GRIp2iHJSLVjBJAjDIz7rmgGwcOFfLItFxSkhK4YVCHaIclItWIEkAMS0gw/nRxDw4eKuTPby0jJTE0tpCISCQoAcS4xATj/kt6cuCQc88bS0hONK46rW20wxKRakAJIA4kJSbw8PBeHDhUyN2vLSY5KYErTj4u2mGJSJwr805gMxtvZvlmtrCU+mFmNt/M5plZjpn1D6tbbWYLiurCypuY2dtmlhs8N47Mx6m+khMTeOzyExnUOZ1fTV7Ii5+si3ZIIhLnyjMUxARg6BHqpwE93b0XcA0wrlj9IHfvVWxC4juAae7eMdj+jnJHXIPVSkrkbz/ow+kd07j9lflM/mx9tEMSkThWZgJw9xnA1iPU7/JvZjepC5RnIJthwMRgeSJwQTm2EUJzD48dkc0pbZty64ufM3X+hmiHJCJxKiKDwZnZhWa2FHid0FlAEQf+a2afmtnosPJm7r4RIHjOOMK+RwdNSzkFBQWRCDfu1UlJZNzIbPoc15ibX5jHmws3RTskEYlDEUkA7j7Z3bsQ+iY/JqzqNHfvDZwF3GBmA45h32PdPdvds9PT0yMRbrVQt1YS4686ie6tGnLTpLlMW5IX7ZBEJM5EdDjooLmovZmlBa83BM/5wGSgb7Bqnpm1AAie8yMZR01Rv3YyE6/pS5fmDfjR3+cyY7nOkESk/CqcAMysgwUD1ZhZbyAF2GJmdc2sflBeF/geUNSTaAowMlgeCbxa0ThqqoZ1knluVF/aZ9TjumdzmLVic7RDEpE4UZ5uoJOA2UBnM1tvZqPM7Hozuz5Y5WJgoZnNA/4CXBpcFG4GzDSzz4E5wOvu/mawzb3AEDPLBYYEr+UYNUpN4e+j+nJc01RGTcxhzqpSr9mLiBxm33TgiX3Z2dmek5NT9oo1VP7OfQwf+xF52/fx3LUn0ztTt1eICJjZp8W64ofKlQCql03b93Hp2Nls3bWf31/YjQa1kyl0p9Ch0B0Plj14HSqjxHUKD6/rFBY6DiSYkZBgJJqRYHyznBCqS0yw0DqHl8PWCdZLDPZROymRri0bkKiZz0QqlRJADfLlV3u59MnZrN+2N9qhlGlAp3QeHd6LRqkp0Q5FpNpSAqhhdn19kGWbdoa+gQffvq1oOaGoLDTsdNHyt9b5Vn2oDEJnBYeCs4ZDhaEziMJCOORFy6H6wsJg3aJ13DkUlBWts2zTTu57cxnNGtbiyR9k07Vlgyj/1ESqJyUAiUmfrd3Gj/4+l6/27udPF/dgWK9W0Q5JpNopLQFE9D4AkaN1YmZjXrupPz1aNeLmF+bx+6mLOXioMNphidQISgASden1a/GP607mqn5ZjJu5ihFPz2HLrq+jHZZItacEIDEhOTGBu88/gQe/35O5a7dx3mMzWbB+e7TDEqnWlAAkplzUuzUv/6gfZsbFT8zipRzNeyBSWZQAJOZ0a9WQ127qz0lZjfn5v+Zz56sL2X9Q1wVEIk0JQGJSk7opTLy6L6MHtOPZ2Wu4/KmPyN+5L9phiVQrSgASs5ISE/jl2cfz2GUnsmjDDs59dCafrtkW7bBEqg0lAIl55/VsyeQb+lE7OZHhY2fz/Mdrox2SSLWgBCBxoUvzBrx2Y39O65DGLycv4I6X5/P1wUPRDkskrikBSNxomJrM0yNP4sZBHXjhk3V8/8mP2Lg99sc7EolVSgASVxITjJ+d2ZknftCHFXk7Oe+xmXz8xZZohyUSl5QAJC4N7dacV288jQZ1krli3Mc88+Eq4mlcK5FYoAQgcatDRn3+fcNpDOycwW9fW8ytL37OvgO6LiBSXknRDkCkIhrUTmbsiD48Pn0FD72znLeX5DGgUzrf6ZzBwM7pNK1XK9ohisQsJQCJewkJxo8Hd+SUdk15Ze563l2az+vzN2IGvdo0YnCXDAZ1yaBriwaYafYxkSJlzgdgZuOBc4F8d+9WQv0wYAxQCBwEbnH3mWbWBngWaB7UjXX3R4Jt7gauAwqC3fzS3d8oK1jNByDlUVjoLN64g2lL8nl3WT6fr/sKgOYNajOoSwbf6ZLBaR2akpqi7z9SMxzzhDBmNgDYBTxbSgKoB+x2dzezHsCL7t7FzFoALdx9rpnVBz4FLnD3xUEC2OXu9x/Nh1ACkGNRsPNr3luWz7tL8/kgdzO7vj5ISlICp7ZryuDjMxjUOYM2TVKjHaZIpSktAZT5FcjdZ5hZ1hHqd4W9rAt4UL4R2Bgs7zSzJUArYPHRhS5SMen1a3FJdhsuyW7D/oOFfLJ6K+8uDSWEO19dBCyiU7N6DOqSweAuzeid2YikRPWPkOqvXFNCBglgaklnAEH9hcAfgQzgHHefXcL2M4Bu7r4jOAO4CtgB5AC3unuJg7yY2WhgNEBmZmafNWvWlOdziZTLFwW7DieDOau2crDQaVgnmTM6pfOdLqELyZqwXuJdheYELisBhK03ALjT3b8bVlYPeB+4x91fCcqaAZsJnS2MIdRUdE1ZcagJSCrTjn0HmJm7mXeX5jN9aT5bdu+nfq0kHrq0F9/t2iza4Ykcs2NuAjoaQXNRezNLc/fNZpYMvAz8o+iff7BeXlhgTwFTIxmHyLFoUDuZs7u34OzuLSgsdOat/4o7X13Itc/mcPPgjtw8uCMJCepFJNVHhRs6zayDBX3rzKw3kAJsCcqeBpa4+4PFtmkR9vJCYGFF4xCJpIQEo3dmY/51fT8u6t2KR6blct2zOezYdyDaoYlETJlnAGY2CRgIpJnZeuAuIBnA3Z8ALgauNLMDwF7g0qBHUH9gBLDAzOYFuyvq7nmfmfUi1AS0GvhhBD+TSMTUTk7kgUt60rN1I8ZMXcywxz/kyRF96NSsfrRDE6mwcl0DiBW6BiDRNGfVVv73H3PZs/8g91/Sk7O7tyh7I5EYUNo1APV1Eymnvm2bMPWm/nRuXp///cdc7v3PUg4Vxs8XKJHilABEjkLzhrV5YfQpXH5yJk+8v5KrnpnDtt37ox2WyDFRAhA5SrWSEvnDhd2596LufPzFVs57fCaLNmyPdlgiR00JQOQYDe+byT9/eAoHDzkX/20W//7sy2iHJHJUlABEKuDEzMa8dlN/erRqxC3/nMfvXlvMgUOF0Q5LpFyUAEQqKL1+Lf5x3clc1S+L8R+u4gfjPmbzrq+jHZZImZQARCIgOTGBu88/gYcu7cm8dV9x3mMzDw9DLRKrlABEIujCE1vz8o/6kWDGJU/O5sVP1kU7JJFSKQGIRFi3Vg157ab+9M1qwm0vz+dXkxew/6CuC0jsUQIQqQRN6qYw4eqT+OEZ7fjHx2sZPnY2eTv2RTsskW9RAhCpJEmJCfzirON5/PITWbppJ+c+NpOc1VujHZbIYUoAIpXs3B4tmfy/p5GaksjwsR9xywuf8dnaEuc/EqlSmhVbpAp0bl6fKTf25+F3lvNSznr+PW8DPVs35KrTsji7ewtqJSVGO0SpgTQaqEgV2/X1QV6Zu54Js1bzRcFu0uqlcHnfTK445TiaNagd7fCkGqrQlJCxQglAqpPCQmfmis1MnLWad5flk2jGWd1bcFW/4+id2ZhgniWRCquSKSFFpPwSEowBndIZ0CmdNVt28+zsNbyYs47XPt9A91YNGdkvi3N7tKB2spqHpHLoDEAkhuz++iCTP/uSibNWk5u/iyZ1i5qHMmnRsE60w5M4pSYgkTji7sxauYUJs1bzzpI8EswYekJzRvbL4qQsNQ/J0TnmJiAzGw+cC+S7e7cS6ocBY4BC4CBwi7vPDOqGAo8AicA4d783KG8C/BPIIjQn8PfdXf3iRAJmxmkd0jitQxrrtu7huY/W8MKctby+YCNdWzTgqn5ZnN+rpZqHpELKPAMwswHALuDZUhJAPWB3MBF8D+BFd+9iZonAcmAIsB74BLjM3Reb2X3AVne/18zuABq7++1lBaszAKnJ9u4/xL/nfcmED1ezLG8njVOTufSkTK7ql0Xzhuo9JKU75jmB3X0GUOrti+6+y7/JInWBouW+wAp3/8Ld9wMvAMOCumHAxGB5InBBeT6ESE1WJyWRy/pm8uYtpzPpulM4uW1Txs5YyYA/T+fuKYs01IQctYj0AjKzC4E/AhnAOUFxKyB8KMT1wMnBcjN33wjg7hvNLCMScYjUBGbGqe2bcmr7pqzbuofH313Bcx+tYdKctVx+ciY/GtiejPo6I5CyRWQoCHef7O5dCH2THxMUl3SV6qivOJvZaDPLMbOcgoKCCkQpUv20aZLKn/6nB9NvHcj5PVvy7Ow1nP6n6YyZupiCnZqURo4somMBBc1F7c0sjdA3/jZh1a2BDcFynpm1AAie84+wz7Hunu3u2enp6ZEMV6TayGyayp8v6cm0n57BuT1a8syHqzj9vne55/XFmp1MSlXhBGBmHSzok2ZmvYEUYAuhi74dzaytmaUAw4EpwWZTgJHB8kjg1YrGISKQlVaXB77fk2m3DuTsbi14euYqTv/TdP74xhK2KBFIMeXpBTQJGAikAXnAXUAygLs/YWa3A1cCB4C9wM/DuoGeDTxMqBvoeHe/JyhvCrwIZAJrgUvcvcxxctULSOTorCzYxePvruDVeV9SOzmRK0/NYvSAdjSpmxLt0KQK6UYwkRpsRf4uHns3lymfb6BOciIj+2Ux+vR2NFYiqBGUAESEFfk7eWTaCqbO30BqciJXnZbFdae3o1GqEkF1pgQgIoctz9vJI9NyeWPBRuqmJHH1aVlc278dDVOTox2aVAIlABH5f5Zt2skj05bzxoJN1K+VxNX92zLqtLZKBNWMEoCIlGrJxh08Oi2X/yzcRFKC0TuzMQM6pTGgUzrdWjYkIUGDz8UzJQARKdOSjTt47fMNvL+8gEUbdgDQpG4K/TuEksGAjmlkaNayuKMEICJHpWDn18xcUcCM5Zv5ILeAzbv2A9CleX3O6JTOGZ3S6ZPVWPMZxwElABE5ZoWFzuKNO5iRW8CM5QV8umYbBw45dZITObV9UwZ0DJ0htE2rq7kKYpASgIhEzK6vD/LRyi2HE8LqLXsAaN24TtBUlE6/Dk1pUFsXk2OBEoCIVJq1W/bwfm4B7y8rYPbKzezef4jEBKN3ZiPOPKE5V5/WlkRdSI4aTQovIpUms2kqI5oex4hTjmP/wULmrt3GjOUFvL+8gN+/voSDhc71Z7SPdphSTERHAxURSUlK4JR2TbltaBem3tSfoSc05/63lrFg/fZohybFKAGISKUxM+69uDtp9Wpx8wufsWf/wWiHJGGUAESkUjVKTeHBS3uyastufvfa4miHI2GUAESk0vVrn8YPB7TnhU/W8ebCjdEORwJKACJSJX46pBPdWzXkjlcWsGm7JrCPBUoAIlIlUpISeHh4L74+UMhPX5xHYWH8dEGvrpQARKTKtE+vx13ndWXWyi2M/eCLaIdT4ykBiEiVuvSkNgw9oTkP/FddQ6NNCUBEqlRR19CmddU1NNrKTABmNt7M8s1sYSn1V5jZ/OAxy8x6BuWdzWxe2GOHmd0S1N1tZl+G1Z0d0U8lIjGtUWoKD34/1DV0zFR1DY2W8pwBTACGHqF+FXCGu/cAxgBjAdx9mbv3cvdeQB9gDzA5bLuHiurd/Y1jCV5E4le/DmmMHtCOSXPW8ebCTdEOp0YqMwG4+wxg6xHqZ7n7tuDlR0DrElYbDKx09zXHFKWIVEu3DukcdA2dr66hURDpawCjgP+UUD4cmFSs7Mag2Wi8mTUubYdmNtrMcswsp6CgIJKxikiUqWtodEUsAZjZIEIJ4PZi5SnA+cBLYcV/A9oDvYCNwAOl7dfdx7p7trtnp6enRypcEYkR4V1Dn1LX0CoVkQRgZj2AccAwd99SrPosYK675xUVuHueux9y90LgKaBvJOIQkfhU1DX0/v8uY+GX6hpaVSqcAMwsE3gFGOHuy0tY5TKKNf+YWYuwlxcCJfYwEpGawcz440WhrqE/nqSuoVWlPN1AJwGzgc5mtt7MRpnZ9WZ2fbDKnUBT4K9Bl86csG1TgSGEEkS4+8xsgZnNBwYBP4nEhxGR+NW4bnjX0CXRDqdGKHNGMHe/rIz6a4FrS6nbQyg5FC8fUd4ARaTmKOoa+uT7X3BGp3SGdmse7ZCqNd0JLCIxRV1Dq44SgIjElPCuobe+pK6hlUkJQERiTvv0etx5Xlc+XLGFcTPVNbSyKAGISEwaflIbzjyhGX9+S11DK4sSgIjEJDPj3ot6hLqGatTQSqEEICIx63DX0M3qGloZlABEJKZ9M2roWt5apFFDI0kJQERi3q1DOtOtVQPueHk+eTvUNTRSlABEJOalJCXwyPAT2adRQyNKCUBE4kJ419DbXp7PvgOHoh1S3CtzKAgRkVgx/KQ2bNy+j0en5bJs007+9oPetG6cGu2w4pbOAEQkbpgZPx3SiXFXZrN6y27Oe2wmH+RqoqhjpQQgInHnu12bMeXG/mTUr83I8XP4y/QVuOu6wNFSAhCRuNQ2rS6Tb+jHuT1a8ue3lvHD5z5l574D0Q4rrigBiEjcSk1J4pHhvfjNuV2ZtjSfYX/5kNy8ndEOK24oAYhIXDMzRvVvy/PXnsyOvQcZ9pcPeX3+xmiHFReUAESkWji5XVOm3tSfLs3rc8Pzc/nDG0s4eKgw2mHFNCUAEak2mjeszQujT2XEKccxdsYXjHh6Dpt3fR3tsGKWEoCIVCspSQmMuaAbD1zSk7lrt3HeYzP5bO22aIcVk8ozKfx4M8s3s4Wl1F9hZvODxywz6xlWtzqY/L34ZPFNzOxtM8sNnhtH5uOIiIRc3Kc1L/+oH4kJxqVPfsTzH69VV9FiynMGMAEYeoT6VcAZ7t4DGAOMLVY/yN17uXt2WNkdwDR37whMC16LiERUt1YNmXpTf05t35RfTl7A7RpC4lvKTADuPgPYeoT6We5edH71EdC6HO87DJgYLE8ELijHNiIiR61RagrjrzqJH3+nAy/mrOeSJ2azftueaIcVEyJ9DWAU8J+w1w7818w+NbPRYeXN3H0jQPCcUdoOzWy0meWYWU5BgW75FpGjl5hg/PR7nXnqymxWb9YQEkUilgDMbBChBHB7WPFp7t4bOAu4wcwGHO1+3X2su2e7e3Z6enqEohWRmmhI12ZMuembIST++l7NHkIiIgnAzHoA44Bh7r6lqNzdNwTP+cBkoG9QlWdmLYJtWwD5kYhDRKQsRUNInNOjJfe9uYzr/15zh5CocAIws0zgFWCEuy8PK69rZvWLloHvAUU9iaYAI4PlkcCrFY1DRKS8UlOSeHR4L359zvG8sySf4WM/YkcNTALl6QY6CZgNdDaz9WY2ysyuN7Prg1XuBJoCfy3W3bMZMNPMPgfmAK+7+5tB3b3AEDPLBYYEr0VEqoyZce3p7Xjqyj4s27STayfksHd/zeohZPHU/pWdne05OTllrygichRe+3wDP37hMwZ2SmfsldkkJ1ave2TN7NNiXfEB3QksIsJ5PVtyzwXdmb6sgFtf/JxDNWTOYU0JKSICXH5yJtv3HuBPby6lQZ0kxgzrhplFO6xKpQQgIhL40cD2fLV3P0++/wUN6yTz8zO7RDukSqUEICIS5o6hXdix9yB/mb6ShnWSGT2gfbRDqjRKACIiYcyM31/QjR37DvCHN5bSoHYyw/tmRjusSqEEICJSTGKC8dD3e7Fr30F+OXkBDeokc3b3FtEOK+LUC0hEpAQpSQk88YM+9M5szM0vfMaM5dVv7CAlABGRUtRJSeTpq06iQ0Z9fvjcp3y6ptSBkeOSEoCIyBE0rJPMs9f0pXnD2lz9zCcs2bgj2iFFjBKAiEgZ0uvX4rlRfUlNSWLE03NYvXl3tEOKCCUAEZFyaN04lb9f25dCd64Y9zGbtu+LdkgVpgQgIlJOHTLqM/Hqvmzfe4AfPP0xW3fvj3ZIFaIEICJyFLq3bsi4kdms3bqHq5+Zw66vD0Y7pGOmBCAicpROadeUv17em4UbdnDdxJy4nWheCUBE5Bh8t2szHrikJx+t2sKNz3/GwUOF0Q7pqCkBiIgcowtObMVvzz+Bd5bkcdu/5lMYZ8NIaygIEZEKuPLULLbvOcADby+nQZ1k7jqva9wMI60EICJSQTd+pwPb9x5g3MxVNKyTzE+GdIp2SOWiBCAiUkFmxq/OOZ4d+w7wyLRcGtZJ5pr+baMdVpnKMyn8eDPLN7OFpdRfYWbzg8csM+sZlLcxs+lmtsTMFpnZzWHb3G1mXwaTyM8zs7Mj95FERKqemfGHC7sz9ITmjHl9MZ+v+yraIZWpPBeBJwBDj1C/CjjD3XsAY4CxQflB4FZ3Px44BbjBzLqGbfeQu/cKHm8cfegiIrElKTGB+y7pQXq9Wvxy8oKY7xlUZgJw9xlAqUPgufssd98WvPwIaB2Ub3T3ucHyTmAJ0KrCEYuIxLAGtZO5+/wTWLRhBxNmrY52OEcU6W6go4D/FC80syzgRODjsOIbg2aj8WbWuLQdmtloM8sxs5yCguo3HreIVD9ndWvOoM7pPPj2cjZ8tTfa4ZQqYgnAzAYRSgC3FyuvB7wM3OLuReOo/g1oD/QCNgIPlLZfdx/r7tnunp2enh6pcEVEKo2Z8bth3Sh0564pi6IdTqkikgDMrAcwDhjm7lvCypMJ/fP/h7u/UlTu7nnufsjdC4GngL6RiENEJFa0aZLKT77bibcX5/HWok3RDqdEFU4AZpYJvAKMcPflYeUGPA0scfcHi20TPrnmhUCJPYxEROLZNf3b0qV5fe6esigmB40rTzfQScBsoLOZrTezUWZ2vZldH6xyJ9AU+GvQpTMnKD8NGAF8p4TunveZ2QIzmw8MAn4S0U8lIhIDkhMTuOfC7mzasY8H/7u87A2qWJk3grn7ZWXUXwtcW0L5TKDE+6HdfUR5AxQRiWd9jmvMFSdnMmHWKi48sRXdWzeMdkiHaTA4EZFK9vMzu9A0uDfgUAwNGKcEICJSyRrWSebOc7uy4MvtPDt7dbTDOUwJQESkCpzbowVndErn/reWsXF7bNwboAQgIlIFzIzfX9CNQ+7cHSP3BigBiIhUkTZNUvnx4I68tSiPtxfnRTscJQARkap03ent6NysPne9upDdUb43QAlARKQKJScm8IeLurFh+z4eeju69wYoAYiIVLE+xzXh8pMzeWbWahZ+uT1qcSgBiIhEwe1ndqFxajK/iuK9AUoAIiJR0DA1md+c25XP12/n7x+tiUoMSgAiIlFyfs+WnN4xjT+/tYxN2/dV+fsrAYiIREnRvQEHDhXyu6lVf2+AEoCISBQd17QuPx7ckTcWbGLakqq9N0AJQEQkyq47vR0dM+px56uL2LO/6u4NUAIQEYmylKQE/nBRd778ai+PvJNbZe+rBCAiEgNOymrC8JPaMG7mKhZv2FH2BhGgBCAiEiPuOKsLjeokV9m8AUoAIiIxolFqCr85tyvz1n3F8x9X/r0BSgAiIjFkWK+W9O+Qxn1vLiN/R+XeG1CeSeHHm1m+mS0spf4KM5sfPGaZWc+wuqFmtszMVpjZHWHlTczsbTPLDZ4bR+bjiIjENzNjzAXd+PpQIb+durhS36s8ZwATgKFHqF8FnOHuPYAxwFgAM0sE/gKcBXQFLjOzrsE2dwDT3L0jMC14LSIiQNu0utw0qAOvz9/I9GX5lfY+ZSYAd58BbD1C/Sx33xa8/AhoHSz3BVa4+xfuvh94ARgW1A0DJgbLE4ELjj50EZHqa/QZ7WifXpff/Hshe/cfqpT3iPQ1gFHAf4LlVsC6sLr1QRlAM3ffCBA8Z5S2QzMbbWY5ZpZTUFAQ4XBFRGJTraRE/nBhd9Zv28sj0yrn3oCIJQAzG0QoAdxeVFTCakfdr8ndx7p7trtnp6enVyREEZG4cnK7pnw/uzXjPviCpZsif29AUiR2YmY9gHHAWe6+JSheD7QJW601sCFYzjOzFu6+0cxaAJXXyCUiEsd+cdbxbNy+j8LCyO+7wmcAZpYJvAKMcPfw+c0+ATqaWVszSwGGA1OCuinAyGB5JPBqReMQEamOGtdN4blRJ9O1ZYOI77vMMwAzmwQMBNLMbD1wF5AM4O5PAHcCTYG/mhnAwaDJ5qCZ3Qi8BSQC4929aLzTe4EXzWwUsBa4JKKfSkREymTu0ZmK7FhkZ2d7Tk5OtMMQEYkrZvapu2cXL9edwCIiNZQSgIhIDaUEICJSQykBiIjUUEoAIiI1lBKAiEgNFVfdQM2sADjWWRLSgM0RDKcyxHqMsR4fxH6MsR4fKMZIiLX4jnP3/zeWTlwlgIows5yS+sHGkliPMdbjg9iPMdbjA8UYCbEeXxE1AYmI1FBKACIiNVRNSgBjox1AOcR6jLEeH8R+jLEeHyjGSIj1+IAadA1ARES+rSadAYiISBglABGRGipuE4CZtTGz6Wa2xMwWmdnNQXkTM3vbzHKD58Zh2/zCzFaY2TIzO7OEfU4xs4WxGKOZpZjZWDNbbmZLzeziGIvvMjNbYGbzzexNM0uraHzHEqOZNQ3W32VmjxfbV58gxhVm9qgFE1jEQnxmlmpmrwe/20Vmdm9FY4t0jMX2GdVjpYzfc9SPlTLiq5Rj5Zi4e1w+gBZA72C5PrAc6ArcB9wRlN8B/ClY7gp8DtQC2gIrgcSw/V0EPA8sjMUYgd8Cvw+WE4C0WImP0MRC+UUxBdvfHaWfYV2gP3A98Hixfc0BTiU0X/V/CE1hGhPxAanAoGA5BfggEvFF+mcYQ8fKkX7PsXCslPZ7rrRj5Zg+V7TeOOIfJDSt5BBgGdAi7Je2LFj+BfCLsPXfAk4NlusBM4NfaMT+qCMc4zqgbiz+DAnNEFcAHEfon+sTwOhoxBi23lXFDrwWwNKw15cBT8ZKfCXs5xHgulj6GQZlMXGslBFj1I+VI/wdVtmxUp5H3DYBhTOzLOBE4GOgmbtvBAieM4LVWhH6wyiyPigDGAM8AOyJxRjNrFFRnGY218xeMrNmsRKfux8AfgQsADYQ+ufwdCTjO4oYS9MqiLdI+O8/FuIL308j4DxgWiTji1CMsXKslLZto6I4o3yslKiqjpXyivsEYGb1gJeBW9x9x5FWLaHMzawX0MHdJ1dGfFDxGAmdNrYGPnT33sBs4P5Yic/Mkgn9UZ8ItATmEzpbiJijiLHUXZRQFrE+0BGIr2g/ScAk4FF3/yJS8QX7rlCMMXaslCZWjpXStq/0Y+VoxHUCCH6YLwP/cPdXguI8M2sR1Lcg1N4GoW98bcI2b00oA58K9DGz1YRObTuZ2XsxFuMWQt+4ig68l4DeMRRfLwB3X+mh89wXgX6RiO8YYizN+iDe4rHHSnxFxgK57v5wJGKLcIyxdKyUJlaOldL0gso7Vo5W3CYAMzNCp05L3P3BsKopwMhgeSShtrqi8uFmVsvM2gIdgTnu/jd3b+nuWYQu2ix394ExFqMDrwFFcQ0GFsdKfMCXQFczKxptcAiwpKLxHWOMJQpOz3ea2SnBPq8sa5uqjC/Y1++BhsAtFY2rMmKMsWOltBhj5VgpTaUdK8ckWhcfKvog9AfohE6h5gWPs4GmhNpOc4PnJmHb/IpQz5VllNDDAsgisj0bIhYjoYtGM4J9TQMyYyy+6wn9Ic8ndAA2jeLPcDWwFdhF6Jt/16A8G1gYxP84wZ3wsRAfoTMSD36GRfu5NtZ+hjF2rJT2e46VY6W0+CrlWDmWh4aCEBGpoeK2CUhERCpGCUBEpIZSAhARqaGUAEREaiglABGRGkoJQESkhlICEBGpof4P+qZXlIaedxkAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAEICAYAAABWJCMKAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAsPklEQVR4nO3deXxU1f3/8dcnG/ueBQQCsguICBE3REFR3IpLtVIXVJTSr0v1p1XaWktLF2vrVnesCGqLS0UFWxeKAiKoBEV2AggqWxIW2dfk8/tjbnBMExLIJDOTvJ+Pxzxm5px7z/1MkpvP3HPPvcfcHRERqXkSoh2AiIhEhxKAiEgNpQQgIlJDKQGIiNRQSgAiIjWUEoCISA2lBCAiUkMpAUjMMLPVZrbbzHaY2QYzG2dm9cPqs8zsLTPbYmbfmtliM/uDmTUJ6q81s5nF2rzCzJaY2U4zW2lmp4XVnWlmS81sl5l9YGZtDhFbipn9K4jRzeyMYvX9gza2mtnqcnzWUrdd3rbM7PQglt+HlZ1hZoXBz7DoMTSsvpaZjTWzbcHP+P+VFatUX0oAEmsudPf6QE/geOAXAGZ2CjAN+Ajo4u6NgUHAAeC4khoys4HAn4HrgAZAP+DLoC4VmAj8GmgKZAMvlxHbTOAqYEMJdTuBscDPy/qA5dh2mW2ZWTLwCPBJCdXr3L1+2GN8WN0ooCPQBugP3GVmg8qKWaqnpGgHIFISd99gZu8SSgQA9wPPufufwpb5GvjNIZr5LfA7d/84eL82rO4SYJG7vwpgZqOAjWbWxd2XlhDPPuDhYNmCEuo/BT41s7PK8fEOue1ytnUH8B6QXo7thbsGuM7dtwBbzOwZ4FrgncNsR6oBHQFITDKzVsC5wAozqwecDLx2GOsnAllAmpmtMLM1ZvaYmdUJFukGfFG0vLvvBFYG5ZWtQtsOuouuB35XyiLpZpZrZqvM7KHg50fQVXZU+LaD11XxmSUGxV0CCPov88xsYTmW7Wdmn5nZATP7YbG6oWa2PHgMLa0NqXJvmNl24Bsgj9A3/CaE/lYPdr2Y2f3BeYCdZnZPCe1kAMnAD4HT+K5LqWjZ+sDWYutsJdRVVNkquu2/Ab929x0l1C0l9FlbAAOA3sCDYdst2taRbFeqmbhLAMA4Qn2/5fE1ocPbf4YXmllTQv9YTgT6AL8pOpEoUXeRuzcAzgC6AKnAFqCQ0D81ANz9ruA8wOuU3JW5O3h+1N3Xu/tGQv8IzwvKdwANi63TENhuZpnhJ1Ej87G+p9Rtl7WimV0INHD3Es9XuPsGd1/s7oXuvgq4i1ASLNpu0bYOa7tSPcVdAnD3GcDm8DIza29m75jZXDP70My6BMuudvf5hP55hDsHmOLum4O+0CmUP6lIFXD36YSS/V+DLpJPCPWdl3f9LcAaoLTb3S4i7ORx0E3SnlDf/NfhJ1GP8CMcSqnbLse6ZwJZwQieDcCPgNvM7M1SlnfA4ODPZD3fP2l+XDm3K9VQ3CWAUowBbnH33sCdwBNlLN+SUBdDkTVBmcSWh4GBZtaT0DfZ681spJmlw8HzBEcfYv3ngFvMLD04wrsNeCuoex3obmaXmllt4F5gfkkngIsEQyhrB29TzKy2mVlQlxDUJYfeWm0zSymlqUNuu4y2fg10ItTN0xOYBDxDaKRT0TDQTAtpDdwHhCeH54F7zKxJ8EXpRkKJVmqguE8AFhonfgrwqpnNA54mrKugtNVKKNPECDHG3fMJ/cP6tbvPJNSn3Q/IMbNvCY1cmQY8WkoTo4E5QA6wBPgc+ENY25cG77cQ6g68ooyQlhHqWmoJvBu8Lhq/3y94/x8gM3j9XtGKZrbIzK4s57ZLbcvdtwfdPBvcfUNQt9Pdi46KewGzCQ0lnQUsBG4Na/s3hE44fwVMB/7i7hoBVENZPE4IY2ZtgbfcvbuZNQSWuXup//TNbFyw/L+C90OAM9z9J8H7p4Fp7j6h0oMXEYkRcX8E4O7bgFVmdhmEjpfNrMQLg8K8C5wdHAY3Ac4OykREaoy4SwBmNoHQIW7nYGz3MOBKYJiZfUHohNbgYNkTzGwNcBnwtJktAggOl4u6B+YQulho8/9uTUSk+orLLiAREam4uDsCEBGRyIirewGlpqZ627Ztox2GiEhcmTt37kZ3TyteHlcJoG3btmRnZ0c7DBGRuGJmX5VUri4gEZEaSglARKSGUgIQEamhlABERGooJQARkRqqzARQ1gQsZjbYzOab2TwzyzazvkF556Cs6LHNzG4L6kaZ2dqwuvNKaltERCpPeYaBjgMeI3RXxpJMBSa5u5tZD+AVQpN2LyOYzzWYnm8todvgFnnI3f96hHGLiEgFlZkA3H1GcPfN0urDZ0yqR8m3VT4TWOnuJY5FrWxTl+SSk7uDThn16ZjegFZN6pCQUNIdoUVEao6IXAhmZhcDfwLSgfNLWOQKoPitlm82s2uAbOCOYLaiSjE9J5/nZ3+Xe+okJ9IhvT4dM+rTKaPBwcTQsrESg4jUHOW6GVz4/ffLWK4fcK+7nxVWlgKsA7q5e25QlgFsJHS0MBpo4e7Xl9LmcGA4QGZmZu+vvjqyg4itu/ezIm87Obk7yMndzvLcHSzP207utr0Hl6mbEiSG9FBS6JTRgI4Z9TmqkRKDiMQvM5vr7ln/Ux7JBBAsuwo4IZiEGzMbDNzk7mdXtO2srCyP9K0gtu7az/LwxJAXSg55279LDPWKEkPR0UJGA7q2aEhGw9qHaFlEJDaUlgAq3AVkZh0I9e+7mfUCUoBNYYsMoVj3j5m1cPf1wduLCU1bFxWN6iaT1bYpWW2bfq/82137WJ733dFCTu52pufk86+5aw4uc3lWK+4a1IXU+rWqOmwRkQorMwEEE7CcAaQGk6v8htBk1bj7U4TmNr3GzPYTmp/0Rx4cVphZXWAg8JNizd4fTPTtwOoS6qOucd0UTmjblBOKJYYtO0OJYcriDYybtZq3F27gjoGduOqkNiQl6rIKEYkfcTUhTGV0AVXEirwd/HbyIj5cvpEuzRvw2x9048R2zaIdlojI95TWBaSvrBXQIb0+z1/fh6eu6s32PQf40ZiPuXXC52zYuifaoYmIlEkJoILMjEHdm/Pf/3c6PzuzI+8s2sCAB6bx1PSV7DtQGO3wRERKpQQQIXVSErl9YCf+e/vpnNohlfveXsqgh2cwPSc/2qGJiJRICSDCMpvV5ZlrsnjuuhNwYOjYTxn+fDbfbN4V7dBERL5HCaCS9O+czju3ncZdgzrz4fKNnPXgdB7+bw579hdEOzQREUAJoFLVSkrk/87owPt3ns7Z3Zrz8H+Xc9aD03lv0QbiafSViFRPSgBVoEWjOjw65Hgm3HgSdVMSGf7CXIY+N4eV+TvKXllEpJIoAVShk9s349+3nsa9F3Tl86+2MOjhGdz39lJ27j0Q7dBEpAZSAqhiyYkJXN/3aN6/8wwu6tmSp6av5MwHpjPpi3XqFhKRKqUEECVpDWrxl8uOY+L/nUJqgxRunfA5d/1rPoWFSgIiUjWUAKKsV2YT3rypLzf378Crc9fwqzcW6khARKpERCaEkYpJTDDuOLsTBe48OW0ltZIS+M2FXTHTHAQiUnmUAGKEmXHXOZ3Zd6CQZ2euIiUpgV+c20VJQEQqjRJADDEz7jn/GPYXFDJmxpekJCZw5zmdox2WiFRTSgAxxswYdWE39h0o5LEPVpCSlMCtZ3aMdlgiUg0pAcSghATjjxcfy76CQh6ckkNKUgIjTm8f7bBEpJpRAohRCQnGX354HPsLnPveXkpyYgLD+h4d7bBEpBpRAohhiQnGg5cfx/4DhYx+azEpSQlcfVKbaIclItWErgOIccmJCfxtyPGcdUw6v35jIS/P+TraIYlINVFmAjCzsWaWZ2YLS6kfbGbzzWyemWWbWd+wutVmtqCoLqy8qZlNMbPlwXOTyHyc6iklKYHHr+xFv05pjJy4gImfrYl2SCJSDZTnCGAcMOgQ9VOB49y9J3A98Pdi9f3dvWexCYlHAlPdvWOw/shyR1xD1UpKZMzVvTm5XTPufPULJn+xLtohiUicKzMBuPsMYPMh6nf4d/cuqAeU5z4Gg4HxwevxwEXlWKfGq52cyN+HZpHVpim3vTyPdxZuiHZIIhLHInIOwMwuNrOlwL8JHQUUceA9M5trZsPDyjPcfT1A8JweiThqgropSYy97gR6tGrELRM+Y+qS3GiHJCJxKiIJwN1fd/cuhL7Jjw6rOtXdewHnAjeZWb/DbdvMhgfnFrLz8zXBOkD9WkmMu64PXZo35KcvfsYMTTwvIkcgoqOAgu6i9maWGrxfFzznAa8DfYJFc82sBUDwnHeINse4e5a7Z6WlpUUy3LjWqE4yLwzrQ7u0etz4fDazV26KdkgiEmcqnADMrIMFdywzs15ACrDJzOqZWYOgvB5wNlA0kmgSMDR4PRR4s6Jx1ESN66bwjxtOJLNpXYaNn0P26lJP1YiI/I/yDAOdAMwGOpvZGjMbZmYjzGxEsMilwEIzmwc8DvwoOCmcAcw0sy+AT4F/u/s7wTr3AQPNbDkwMHgvR6BZ/Vr848YTad6wNtc+N4fPv94S7ZBEJE5YPE0+kpWV5dnZ2WUvWANt2LqHy5+ezZZd+5hw40l0b9ko2iGJSIwws7nFhuIDuhK42mjeqDb/vPFEGtZO5qpnP2HJ+m3RDklEYpyOAKqZrzft4vKnZ7O/oJAHLj+OBrWTKHQoKHQKCz302p1CD70vCMoKg7LQe6ewMLScu1MQvMYdMyPBjASDBDMseE5IKHofqjOC57BlExL43vq1khI5PrMxyYn6HiJSmUo7AlACqIa+zN/Bj8Z8TP72vdEOpUx9jm7K4z/uRVqDWtEORaTaUgKoYTbu2MuCNVtJSDASi76FJ4S+fScG39ZDr+3gt/PE4Bt8YrCOGd+rNwzH8YNHDFBYGHrvfHck4R52VFFYVPbdUUahg7uzLHc7o99aTKM6yTx5VW96ZeqWUCKVQQlAYtLiddv4yYvZ5G7dy6gfdOPHJ2ZGOySRakcngSUmdT2qIZNv7stJ7Zvxy9cXMPK1+ew9UBDtsERqBCUAibrGdVN47toTuKl/e16a8w2XP/0x67fujnZYItWeEoDEhMQE4+fndOGpq3qzInc7Fz46k4+/1O0tRCqTEoDElEHdm/PmzafSsE4yV/79E8bOXEU8nacSiSdKABJzOqQ34M2bTmVAl3R+99Zibn95Hrv36byASKQpAUhMalA7maev6s0dAzvx5hfruPTJWXyzeVe0wxKpVpQAJGYlJBi3nNmRsdeewJotu7jg0ZlM19wHIhGjBCAxr3/ndCbf0pcWjWpz7XOf8vgHK3ReQCQClAAkLrRpVo+J/3cKF/Q4ir+8u4wRL85lx94D0Q5LJK4pAUjcqJuSxN+u6Mk95x/Df5fkMfixmazM3xHtsETilhKAxBUz44bT2vHCsD58u2s/gx/7iPcWbYh2WCJxSQlA4tIp7VOZfEtf2qXVY/gLc3ngvWUUFOq8gMjhUAKQuHVU4zq88pOTuTyrFY++v4Jh4+eweee+aIclEjeSoh2ASEXUTk7kz5f2oEerxvx28iJO+MN/6d2mCQO6pNO/czqdMupjZtEOUyQmlXk7aDMbC1wA5Ll79xLqBwOjgULgAHCbu880s9bA80DzoG6Muz8SrDMKuBEoGtT9S3f/T1nB6nbQcijLNmxn0hdreX9p/sEpMVs2rsMZndMY0CWdU9qnUiclMcpRilS9I54PwMz6ATuA50tJAPWBne7uZtYDeMXdu5hZC6CFu39mZg2AucBF7r44SAA73P2vh/MhlACkvDZs3cMHy/L4YGkeM1dsZNe+AlKSEji5XTP6d05jQJcMMpvVjXaYIlWitARQZheQu88ws7aHqA8fh1cP8KB8PbA+eL3dzJYALYHFhxe6yOFr3qg2Q/pkMqRPJnsPFDBn1RbeX5rHtGV5jJq8mFGTF9MurR4DOqfTv0s6J7RtSkqSTolJzVKuGcGCBPBWSUcAQf3FwJ+AdOB8d59dwvozgO7uvi04ArgW2AZkA3e4+5ay4tARgETC6o07+WBZHu8vzeOTLzezr6CQeimJ9O2YyoAu6ZzROZ2MhrWjHaZIxFRoSsiyEkDYcv2Ae939rLCy+sB04A/uPjEoywA2EjpaGE2oq+j6UtocDgwHyMzM7P3VV1+VGa9Iee3ad4CPVmw62F20fuseALod1ZD+ndM579gWdD2qYZSjFKmYKkkAwbKrgBPcfaOZJQNvAe+6+4MVbVtHAFKZiiaqf39pHtOW5jP36y24OyPP7cKNp7XTaCKJW0d8DqAcDXcAVgYngXsBKcAmC+0tzwJLiv/zN7MWwTkCgIuBhRWNQ6SizIwuzRvSpXlD/u+MDmzZuY9fvbGAP/5nKfPXbOX+H/agbopGTkv1UeZfs5lNAM4AUs1sDfAbIBnA3Z8CLgWuMbP9wG7gR0Ey6AtcDSwws3lBc0XDPe83s56EuoBWAz+J4GcSiYgm9VJ4/Me9eGr6l9z/7lJW5O3g6at706ZZvWiHJhIR5eoCihXqApJomZ6Tz60TPgfgb0OO5/ROaVGOSKT8SusC0rg3kXI4vVMak2/+bk6CJ6ZpTgKJf0oAIuWU2azuwTkJ7n9nGTf98zN2ak4CiWNKACKHoWhOgl+ddwzvLNzAxU98xKqNO6MdlsgRUQIQOUxmxo392vH89SeSv30vP3hsJu8vzY12WCKHTQlA5Aj17ZjKpJv70rpJXYaNz+bRqcsp1JwEEkeUAEQqoHXTurz201MYfNxRPDAlhxEvzmX7nv3RDkukXJQARCqoTkoiD/2oJ/de0JWpS/O46PGPNFexxAUlAJEIMDOu73s0Lw478eBcxVMW67yAxDYlAJEIOrl9Mybd0pejU+tx4/PZPDQlR+cFJGYpAYhEWMvGdXh1xMn8sHcrHpm6nBufz2abzgtIDFICEKkEtZMT+csPezB6cDem5+Rz0WMfsTx3e7TDEvkeJQCRSmJmXH1yW/5540ls27Ofix7/iHcWri97RZEqogQgUsn6HN2Ut245jY4ZDRjx4mdcMWY27yxcz4GCwmiHJjWc7gYqUkX2Hihg/KzVjJ/1FWu/3U3LxnW46qQ2XHFCa5rUS4l2eFKNVWhGsFihBCDVQUGh898luYyftZpZKzdRKymBi3q2ZOgpbTX9pFQKJQCRGLRsw3bGz17N65+tZff+Avq0bcq1p7bl7K4ZJCWqh1YiQwlAJIZt3bWfV7K/4fmPV/PN5t20aFT7YPdQs/q1oh2exDklAJE4UFDovL80j/GzVjNzxUZSkhL4wXFHce0pbeneslG0w5M4VWmTwotI5CQmGAO7ZjCwawbLc0PdQ6/NXcu/5q4hq00Thp7SlkHdm5Os7iGJgDL/isxsrJnlmdnCUuoHm9l8M5tnZtnBZPBFdYPMbJmZrTCzkWHlTc1sipktD56bRObjiFQfHTMa8PuLjuXjX57JPecfQ972vdwy4XP6/vl9Hp26nI079kY7RIlzZXYBmVk/YAfwvLt3L6G+PrDT3d3MegCvuHsXM0sEcoCBwBpgDjDE3Reb2f3AZne/L0gMTdz97rKCVReQ1GQFhc60ZXmMm7WaD5dvJCUxgQt6tODGfu04poVGD0npjrgLyN1nmFnbQ9SH3/e2HlCUUfoAK9z9yyCAl4DBwOLg+YxgufHANKDMBCBSkyUmGGcek8GZx2SwIm8Hz89ezWtz1zDx87Wcd2xzfnZmJzo3bxDtMCWORKQj0cwuNrOlwL+B64PilsA3YYutCcoAMtx9PUDwnH6ItocHXUvZ+fn5kQhXJO51SK/P7wZ356ORA7i5fwemL8tn0CMzuOmfn+meQ1JuEUkA7v66u3cBLgJGB8VW0qJH0PYYd89y96y0tLQKRClS/TSum8Kd53Rm5t0D+Onp7Zm2NI+zH57BLRM+Z0WeEoEcWkSHErj7DKC9maUS+sbfOqy6FbAueJ1rZi0Ague8SMYhUtM0qZfCXYO68OHdA/hJv/ZMXZLLwIdm8LOXPtfsZFKqCicAM+tgZha87gWkAJsInfTtaGZHm1kKcAUwKVhtEjA0eD0UeLOicYgINK2Xwshzu/DhXf0Zflo73luUy8AHp3P7y/NYtXFntMOTGFOeUUATCJ2wTQVygd8AyQDu/pSZ3Q1cA+wHdgM/d/eZwbrnAQ8DicBYd/9DUN4MeAXIBL4GLnP3zWUFq1FAIodn4469PD19JS98/BX7DhRy0fEtuXVAR9qm1ot2aFKFdCWwSA2Wt30PT0//khc//ooDhc4lx7fklgEdyWxWN9qhSRVQAhAR8rbt4cnpK/nHJ19TWOhc2qsVNw/oQOumSgTVmRKAiByUu20PT05byT8/DSWCy7JacVP/DrRqokRQHSkBiMj/2LB1D09MW8FLn36D41yW1Zqf9GtHm2Y6R1CdKAGISKnWfbubJ6at4OU537C/wGmXWo9+ndLo1ymVk9o1o26K7hsZz5QARKRM677dzTsLNzBjeT4ff7mJPfsLSUlMIKttE07rGEoIXVs0JBj5LXFCCUBEDsue/QVkr97CjOX5zMjJZ+mG0JXFqfVr0a9jKv06pdG3YyqpmrAm5ikBiEiF5G3bw4zlG5mRk8/MFRvZvHMfAN1bNqRfxzT6dUqjV2YTUpI0V0GsUQIQkYgpLHQWrtvKjJx8ZuRs5LOvt3Cg0KmXksjJ7VPp1ymVfh3TdMFZjFACEJFKs33Pfmav3BR0F23k6827AMhsWpdzumXw83O66MggijQlpIhUmga1kzm7W3PO7tYcgNUbdzJjeT7Tl+XzzIerSExIYOS5XaIcpRSnlCwiEdc2tR7XnNyWZ689gSF9Mnl6xkpmrdwY7bCkGCUAEalUv77gGI5Orcf/e/kLtgQnjiU2KAGISKWqm5LE3644nk079/KLiQuIp/OO1Z0SgIhUuu4tG/HzczrzzqINvDznm7JXkCqhBCAiVeKGvu3o2yGV305erFnKYoQSgIhUiYQE44HLj6NWcgK3vTSPfQcKox1SjacEICJVJqNhbf58aQ8WrN3Kg1Nyoh1OjacEICJV6pxuzTU0NEYoAYhIldPQ0NhQZgIws7FmlmdmC0upv9LM5gePWWZ2XFDe2czmhT22mdltQd0oM1sbVndeRD+ViMQ0DQ2NDeU5AhgHDDpE/SrgdHfvAYwGxgC4+zJ37+nuPYHewC7g9bD1Hiqqd/f/HEnwIhK/NDQ0+spMAO4+A9h8iPpZ7r4lePsx0KqExc4EVrr7V0cUpYhUSzf0bcepHZppaGiURPocwDDg7RLKrwAmFCu7Oeg2GmtmTUpr0MyGm1m2mWXn5+dHMlYRibKEBOOBy3pqaGiURCwBmFl/Qgng7mLlKcAPgFfDip8E2gM9gfXAA6W16+5j3D3L3bPS0tIiFa6IxIjmjb4bGvrAlGXRDqdGiUgCMLMewN+Bwe6+qVj1ucBn7p5bVODuue5e4O6FwDNAn0jEISLxqWho6JgZXzJrhYaGVpUKJwAzywQmAle7e0lXdgyhWPePmbUIe3sxUOIIIxGpOQ4ODX1FQ0OrSnmGgU4AZgOdzWyNmQ0zsxFmNiJY5F6gGfBEMKQzO2zdusBAQgki3P1mtsDM5gP9gdsj8WFEJH5paGjV05SQIhJTnp6+kj+9vZT7LjmWK/pkRjucaqG0KSF1JbCIxJQbT9PQ0KqiBCAiMUVDQ6uOEoCIxBwNDa0aSgAiEpM0NLTyKQGISMwqGhp6+yvzNDS0EigBiEjMKhoaunnnPkZOnK+hoRGmBCAiMa17y0bceXZn3l2Uy0u6a2hEKQGISMwrGhr6Ow0NjSglABGJeRoaWjmUAEQkLoQPDR02fo5OCkeAEoCIxI1zujXnvkuO5ZMvN3PhYzNZuHZrtEOKa0oAIhJXruiTySsjTqag0Ln0yVn8a+6aaIcUt5QARCTu9GzdmMm39KVXZhPufPUL7nljgc4LHAElABGJS6n1a/HCsD78pF87Xvz4a64YM5sNW/dEO6y4ogQgInErKTGBX5x3DI//uBdLN2zngkdn8smXxScllNIoAYhI3Du/RwveuOlUGtZO4sd//4RnZ67SVcPloAQgItVCp4wGvHHzqQzoks7otxbzs5fmsWvfgWiHFdOUAESk2mhYO5mnr+rNz8/pzOT567jkiVms3rgz2mHFLCUAEalWEhKMm/p3YNx1fdiwbQ8XPjaTqUtyox1WTCrPpPBjzSzPzBaWUn+lmc0PHrPM7LiwutXB5O/FJ4tvamZTzGx58NwkMh9HRCTk9E5pTL65L5lN6zJsfDYPTcmhsFDnBcKV5whgHDDoEPWrgNPdvQcwGhhTrL6/u/csNiHxSGCqu3cEpgbvRUQiqnXTurz201O4tFcrHpm6nGHj57B11/5ohxUzykwA7j4D2HyI+lnuviV4+zHQqhzbHQyMD16PBy4qxzoiIoetdnIif72sB6Mv6s7MFRu58LGZLFm/LdphxYRInwMYBrwd9t6B98xsrpkNDyvPcPf1AMFzemkNmtlwM8s2s+z8/PwIhysiNYGZcfVJbXhp+MnsPVDAxU98xBufr412WFEXsQRgZv0JJYC7w4pPdfdewLnATWbW73Dbdfcx7p7l7llpaWkRilZEaqLebZow+Za+9GjVmNtenseoSYvYX1BzbyERkQRgZj2AvwOD3f3gZXjuvi54zgNeB/oEVblm1iJYtwWQF4k4RETKkt6gNv+44USuP/Voxs1azY+f+Zi8bTXzFhIVTgBmlglMBK5295yw8npm1qDoNXA2UDSSaBIwNHg9FHizonGIiJRXcmIC917YlUeu6MnCtdu47OnZ5G2veUmgPMNAJwCzgc5mtsbMhpnZCDMbESxyL9AMeKLYcM8MYKaZfQF8Cvzb3d8J6u4DBprZcmBg8F5EpEoN7tmSF284kbxte7nm2U/ZurtmjRCyeLpfRlZWlmdnZ5e9oIjIYZiRk8+w8XPo0aoxLwzrQ92UpGiHFFFmNrfYUHxAVwKLiNCvUxqPXHE8n3+9hZ+++FmNmVtACUBEBDjv2Bb86ZJjmZ6Tz+2vzKOgBlw1XL2Oc0REKuBHJ2Sydfd+/vifpTSsncwfL+6OmUU7rEqjBCAiEmZ4v/Z8u2s/T0xbSeO6ydw9qEu0Q6o0SgAiIsX8/JzOfLt7P09OW0mjOsmMOL19tEOqFEoAIiLFmBmjB3dn2+793Pf2UhrVSWZIn8xohxVxSgAiIiVITDAevLwnO/Ye4JevL6Bh7WTO79Ei2mFFlEYBiYiUIiUpgSev7E3vzCbc9vLnTM+pXjekVAIQETmEOimJPHvtCXRIb8CIF+Yy96tS744fd5QARETK0KhOMs9f34eMhrW47rk51WY+ASUAEZFySGtQixeGnUjdlCSufvbTajHZvBKAiEg5tW5alxeG9aGgsJCrnv2EDVvj+w6iSgAiIoehY0YDxl3Xhy0793H1s5+wZee+aId0xJQAREQO03GtG/PM0Cy+2ryLa8fNYcfeA9EO6YgoAYiIHIFT2qfy2JDjWbh2K8Ofz2bP/oJoh3TYlABERI7Q2d2ac/+lPZi1chO3TvicA3E2v7ASgIhIBVzauxX3XtCV9xbnMnLiAgrj6DbSuhWEiEgFXd/3aLbu3s8jU5fTqE4y95x/TFzcRloJQEQkAm47qyNbd+/n2ZmraFI3mZsHdIx2SGUqz6TwY80sz8wWllJ/pZnNDx6zzOy4oLy1mX1gZkvMbJGZ/SxsnVFmtjaYRH6emZ0XuY8kIlL1zIx7L+jKxce35K/v5TBndezfMqI85wDGAYMOUb8KON3dewCjgTFB+QHgDnc/BjgJuMnMuoat95C79wwe/zn80EVEYktCgvH7i7pzVKPa/Or1BTE/t3CZCcDdZwClpjJ3n+XuW4K3HwOtgvL17v5Z8Ho7sARoWeGIRURiWL1aSfxucHdycnfwzIdfRjucQ4r0KKBhwNvFC82sLXA88ElY8c1Bt9FYM2tSWoNmNtzMss0sOz+/et2KVUSqp7O6ZnBOtwz+NnU5X2/aFe1wShWxBGBm/QklgLuLldcHXgNuc/eiW+g9CbQHegLrgQdKa9fdx7h7lrtnpaWlRSpcEZFKNeoH3UhKMO55cyHusTk0NCIJwMx6AH8HBrv7prDyZEL//P/h7hOLyt09190L3L0QeAboE4k4RERiRYtGdbjj7M7MyMnnrfnrox1OiSqcAMwsE5gIXO3uOWHlBjwLLHH3B4utEz6v2sVAiSOMRETi2dBT2nJsy0b8dvJitu7eH+1w/kd5hoFOAGYDnc1sjZkNM7MRZjYiWOReoBnwRDCkMzsoPxW4GhhQwnDP+81sgZnNB/oDt0f0U4mIxIDEBOOPFx/L5p17+cu7S6Mdzv8o80Iwdx9SRv0NwA0llM8ESrwUzt2vLm+AIiLx7NhWjRh6SlvGzVrNJb1a0Suz1DEvVU73AhIRqWR3nN2ZjAa1+eXEBeyPoRvGKQGIiFSy+rWSGPWDbizdsJ3nPloV7XAOUgIQEakC53TL4Kxj0nloynLWbImNawOUAEREqoCZ8dvB3TGDe99cFBPXBigBiIhUkZaN63D7WZ14f2ke7yzcEO1wlABERKrSdae25ZgWDRk1eRHb90T32gAlABGRKpSUmMCfLjmWvO17eeC9nLJXqERKACIiVaxn68ZcfVIbxs9ezfw130YtDiUAEZEouPOczqTVr8UvX18QtcnklQBERKKgYe1k7r2wKwvXbmP87K+iEoMSgIhIlJx/bAvO6JzGg+8tY923u6t8+0oAIiJRYmaMHtydAndGTVpU5dtXAhARiaLWTevyszM78d7iXN5bVLXXBigBiIhE2Q2nHU3njAaMmrSInXsPVNl2lQBERKIsOTGBP17SnXVb9/DQlKq7NkAJQEQkBvRu05QhfTIZ+9EqFq7dWiXbVAIQEYkRIwd1oWm9FH71+gIKCiv/ZnFKACIiMaJR3WR+fUFXvlizlX98UvnXBigBiIjEkB8cdxSndUzl/neWkbttT6VuqzyTwo81szwzW1hK/ZVmNj94zDKz48LqBpnZMjNbYWYjw8qbmtkUM1sePMfOJJkiIlFUdG3AvoJCfjd5caVuqzxHAOOAQYeoXwWc7u49gNHAGAAzSwQeB84FugJDzKxrsM5IYKq7dwSmBu9FRARom1qPWwd04N8L1vPB0rxK206ZCcDdZwCbD1E/y923BG8/BloFr/sAK9z9S3ffB7wEDA7qBgPjg9fjgYsOP3QRkepreL/2dEivzz1vLGTXvsq5NiDS5wCGAW8Hr1sC34TVrQnKADLcfT1A8JxeWoNmNtzMss0sOz8/P8LhiojEppSkBP5wUXfWfrubR6Yur5RtRCwBmFl/Qgng7qKiEhY77HFN7j7G3bPcPSstLa0iIYqIxJUT2zXj8qxWPPvhKpZu2Bbx9pMi0YiZ9QD+Dpzr7puC4jVA67DFWgHrgte5ZtbC3debWQug8jq5RETi2C/OPYb1W/dQWAlTBlT4CMDMMoGJwNXuHn4N8xygo5kdbWYpwBXApKBuEjA0eD0UeLOicYiIVEdN6qXwwrAT6XpUw4i3XeYRgJlNAM4AUs1sDfAbIBnA3Z8C7gWaAU+YGcCBoMvmgJndDLwLJAJj3b3ofqf3Aa+Y2TDga+CyiH4qEREpk7lX/uXGkZKVleXZ2dnRDkNEJK6Y2Vx3zyperiuBRURqKCUAEZEaSglARKSGUgIQEamhlABERGooJQARkRoqroaBmlk+cKSzJKQCGyMYTmWI9RhjPT6I/RhjPT5QjJEQa/G1cff/uZdOXCWAijCz7JLGwcaSWI8x1uOD2I8x1uMDxRgJsR5fEXUBiYjUUEoAIiI1VE1KAGOiHUA5xHqMsR4fxH6MsR4fKMZIiPX4gBp0DkBERL6vJh0BiIhIGCUAEZEaKm4TgJm1NrMPzGyJmS0ys58F5U3NbIqZLQ+em4St8wszW2Fmy8zsnBLanGRmC2MxRjNLMbMxZpZjZkvN7NIYi2+ImS0ws/lm9o6ZpVY0viOJ0cyaBcvvMLPHirXVO4hxhZn9zYIJLGIhPjOra2b/Dn63i8zsvorGFukYi7UZ1X2ljN9z1PeVMuKrlH3liLh7XD6AFkCv4HUDIAfoCtwPjAzKRwJ/Dl53Bb4AagFHAyuBxLD2LgH+CSyMxRiB3wK/D14nAKmxEh+hiYXyimIK1h8VpZ9hPaAvMAJ4rFhbnwInE5qv+m1CU5jGRHxAXaB/8DoF+DAS8UX6ZxhD+8qhfs+xsK+U9nuutH3liD5XtDYc8Q8SmlZyILAMaBH2S1sWvP4F8Iuw5d8FTg5e1wdmBr/QiP1RRzjGb4B6sfgzJDRDXD7QhtA/16eA4dGIMWy5a4vteC2ApWHvhwBPx0p8JbTzCHBjLP0Mg7KY2FfKiDHq+8oh/g6rbF8pzyNuu4DCmVlb4HjgEyDD3dcDBM/pwWItCf1hFFkTlAGMBh4AdsVijGbWuChOM/vMzF41s4xYic/d9wM/BRYA6wj9c3g2kvEdRoylaRnEWyT89x8L8YW30xi4EJgayfgiFGOs7Culrdu4KM4o7yslqqp9pbziPgGYWX3gNeA2d992qEVLKHMz6wl0cPfXKyM+qHiMhA4bWwEfuXsvYDbw11iJz8ySCf1RHw8cBcwndLQQMYcRY6lNlFAWsTHQEYivqJ0kYALwN3f/MlLxBW1XKMYY21dKEyv7SmnrV/q+cjjiOgEEP8zXgH+4+8SgONfMWgT1LQj1t0HoG1/rsNVbEcrAJwO9zWw1oUPbTmY2LcZi3EToG1fRjvcq0CuG4usJ4O4rPXSc+wpwSiTiO4IYS7MmiLd47LESX5ExwHJ3fzgSsUU4xljaV0oTK/tKaXpC5e0rhytuE4CZGaFDpyXu/mBY1SRgaPB6KKG+uqLyK8yslpkdDXQEPnX3J939KHdvS+ikTY67nxFjMTowGSiK60xgcazEB6wFuppZ0d0GBwJLKhrfEcZYouDwfLuZnRS0eU1Z61RlfEFbvwcaAbdVNK7KiDHG9pXSYoyVfaU0lbavHJFonXyo6IPQH6ATOoSaFzzOA5oR6jtdHjw3DVvnV4RGriyjhBEWQFsiO7IhYjESOmk0I2hrKpAZY/GNIPSHPJ/QDtgsij/D1cBmYAehb/5dg/IsYGEQ/2MEV8LHQnyEjkg8+BkWtXNDrP0MY2xfKe33HCv7SmnxVcq+ciQP3QpCRKSGitsuIBERqRglABGRGkoJQESkhlICEBGpoZQARERqKCUAEZEaSglARKSG+v9MrV/XIcKeAgAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -1638,14 +1748,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f5ded95c",
+   "id": "2f4ea910",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "6ec1ddc6",
+   "id": "691bcb73",
    "metadata": {},
    "source": [
     "If we use as baseline_climate `W5E5` or `GSWP3_W5E5`, we do not need to do any bias correction, when we use the climate data from ISIMIP3b. This is because ISIMIP3b was internally bias-corrected to `W5E5` (add link). "
@@ -1653,10 +1763,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
-   "id": "d33cddb1",
+   "execution_count": 37,
+   "id": "84471de7",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-07-07 10:19:48: oggm.workflow: Execute entity tasks [process_monthly_isimip_data] on 2 glaciers\n"
+     ]
+    },
     {
      "data": {
       "text/html": [
@@ -2027,12 +2144,12 @@
        "    hydro_yr_0:      1850\n",
        "    hydro_yr_1:      2100\n",
        "    author:          OGGM\n",
-       "    author_info:     Open Global Glacier Model</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-7b0d442b-894b-4232-87a6-c7a3f8069747' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-7b0d442b-894b-4232-87a6-c7a3f8069747' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 3012</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-866b6cb8-449b-4fc6-b401-a9cd6e8a45da' class='xr-section-summary-in' type='checkbox'  checked><label for='section-866b6cb8-449b-4fc6-b401-a9cd6e8a45da' class='xr-section-summary' >Coordinates: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>1850-01-01 ... 2100-12-01</div><input id='attrs-77257de1-6514-425f-87c2-e0587fc60134' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-77257de1-6514-425f-87c2-e0587fc60134' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b11278aa-9112-4ebf-bcc0-a945d0982a71' class='xr-var-data-in' type='checkbox'><label for='data-b11278aa-9112-4ebf-bcc0-a945d0982a71' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;1850-01-01T00:00:00.000000000&#x27;, &#x27;1850-02-01T00:00:00.000000000&#x27;,\n",
+       "    author_info:     Open Global Glacier Model</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-eeda28ed-cb94-443d-be94-cb800e3c5c9d' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-eeda28ed-cb94-443d-be94-cb800e3c5c9d' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 3012</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-09b2774f-566f-4a72-a6ea-60d1389d410b' class='xr-section-summary-in' type='checkbox'  checked><label for='section-09b2774f-566f-4a72-a6ea-60d1389d410b' class='xr-section-summary' >Coordinates: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>1850-01-01 ... 2100-12-01</div><input id='attrs-9d83bee3-4ed1-4bd1-a05f-fde7b8b19bc5' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-9d83bee3-4ed1-4bd1-a05f-fde7b8b19bc5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a4521e59-e639-4385-b642-8805e06a2857' class='xr-var-data-in' type='checkbox'><label for='data-a4521e59-e639-4385-b642-8805e06a2857' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;1850-01-01T00:00:00.000000000&#x27;, &#x27;1850-02-01T00:00:00.000000000&#x27;,\n",
        "       &#x27;1850-03-01T00:00:00.000000000&#x27;, ..., &#x27;2100-10-01T00:00:00.000000000&#x27;,\n",
        "       &#x27;2100-11-01T00:00:00.000000000&#x27;, &#x27;2100-12-01T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-3fcccbcd-ee5f-4f2e-8251-f7b69c6e518d' class='xr-section-summary-in' type='checkbox'  checked><label for='section-3fcccbcd-ee5f-4f2e-8251-f7b69c6e518d' class='xr-section-summary' >Data variables: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>prcp</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-4715f338-f286-4d49-b200-00d79061279c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4715f338-f286-4d49-b200-00d79061279c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6fc8e2de-c849-43da-a5c6-7825ac7b83e9' class='xr-var-data-in' type='checkbox'><label for='data-6fc8e2de-c849-43da-a5c6-7825ac7b83e9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>kg m-2</dd><dt><span>long_name :</span></dt><dd>total monthly precipitation amount</dd></dl></div><div class='xr-var-data'><pre>array([172.034   , 139.34789 , 164.74915 , ..., 158.94795 , 111.588615,\n",
-       "        68.630295], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>temp</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-94857016-0d05-4788-9086-34cfed5c3661' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-94857016-0d05-4788-9086-34cfed5c3661' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4d3f7c62-db41-4e66-919f-f2f948722c8c' class='xr-var-data-in' type='checkbox'><label for='data-4d3f7c62-db41-4e66-919f-f2f948722c8c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>degC</dd><dt><span>long_name :</span></dt><dd>2m temperature at height ref_hgt</dd></dl></div><div class='xr-var-data'><pre>array([-4.010132,  0.579407,  1.200287, ...,  9.13678 ,  3.740601, -0.21701 ],\n",
-       "      dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-d9f4bea0-e58d-4328-a02e-6bb820cbeabc' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d9f4bea0-e58d-4328-a02e-6bb820cbeabc' class='xr-section-summary' >Attributes: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>ref_hgt :</span></dt><dd>1764.0</dd><dt><span>ref_pix_lon :</span></dt><dd>8.25</dd><dt><span>ref_pix_lat :</span></dt><dd>46.75</dd><dt><span>ref_pix_dis :</span></dt><dd>32652.873631988525</dd><dt><span>climate_source :</span></dt><dd>_monthly_ISIMIP3b_mri-esm2-0_r1i1p1f1_ssp126_no_OGGM_bias_correction</dd><dt><span>hydro_yr_0 :</span></dt><dd>1850</dd><dt><span>hydro_yr_1 :</span></dt><dd>2100</dd><dt><span>author :</span></dt><dd>OGGM</dd><dt><span>author_info :</span></dt><dd>Open Global Glacier Model</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-8a97b2cc-9a91-4ed9-be0d-b7471a3dec9f' class='xr-section-summary-in' type='checkbox'  checked><label for='section-8a97b2cc-9a91-4ed9-be0d-b7471a3dec9f' class='xr-section-summary' >Data variables: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>prcp</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-b7fff4d9-d985-4633-a06e-3a5cb86af547' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b7fff4d9-d985-4633-a06e-3a5cb86af547' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1941389d-1efb-45d6-8653-54653e021f04' class='xr-var-data-in' type='checkbox'><label for='data-1941389d-1efb-45d6-8653-54653e021f04' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>kg m-2</dd><dt><span>long_name :</span></dt><dd>total monthly precipitation amount</dd></dl></div><div class='xr-var-data'><pre>array([172.034   , 139.34789 , 164.74915 , ..., 158.94795 , 111.588615,\n",
+       "        68.630295], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>temp</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-29c43459-71bd-4955-aa52-d6052a79c3fd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-29c43459-71bd-4955-aa52-d6052a79c3fd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-41bcbc5e-f97d-48ba-9cc6-d766284a82e3' class='xr-var-data-in' type='checkbox'><label for='data-41bcbc5e-f97d-48ba-9cc6-d766284a82e3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>degC</dd><dt><span>long_name :</span></dt><dd>2m temperature at height ref_hgt</dd></dl></div><div class='xr-var-data'><pre>array([-4.010132,  0.579407,  1.200287, ...,  9.13678 ,  3.740601, -0.21701 ],\n",
+       "      dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-1efc8e85-a6e0-4c25-b355-d759f5936626' class='xr-section-summary-in' type='checkbox'  checked><label for='section-1efc8e85-a6e0-4c25-b355-d759f5936626' class='xr-section-summary' >Attributes: <span>(9)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>ref_hgt :</span></dt><dd>1764.0</dd><dt><span>ref_pix_lon :</span></dt><dd>8.25</dd><dt><span>ref_pix_lat :</span></dt><dd>46.75</dd><dt><span>ref_pix_dis :</span></dt><dd>32652.873631988525</dd><dt><span>climate_source :</span></dt><dd>_monthly_ISIMIP3b_mri-esm2-0_r1i1p1f1_ssp126_no_OGGM_bias_correction</dd><dt><span>hydro_yr_0 :</span></dt><dd>1850</dd><dt><span>hydro_yr_1 :</span></dt><dd>2100</dd><dt><span>author :</span></dt><dd>OGGM</dd><dt><span>author_info :</span></dt><dd>Open Global Glacier Model</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -2054,7 +2171,7 @@
        "    author_info:     Open Global Glacier Model"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2063,15 +2180,14 @@
     "ssp = 'ssp126'  # 'ssp585' #126'\n",
     "ensemble = 'mri-esm2-0_r1i1p1f1'\n",
     "fs = '_monthly_ISIMIP3b_{}_{}'.format(ensemble, ssp)\n",
-    "for gdir in gdirs:\n",
-    "    tasks.process_monthly_isimip_data(gdir, ensemble=ensemble, ssp=ssp, output_filesuffix=fs)\n",
+    "workflow.execute_entity_task(tasks.process_monthly_isimip_data, gdirs, ensemble=ensemble, ssp=ssp, output_filesuffix=fs)\n",
     "# this is the processed \n",
     "xr.open_dataset(gdir.get_filepath('gcm_data', filesuffix=fs))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "7c705d4f",
+   "id": "24aa3556",
    "metadata": {},
    "source": [
     "### Do projection run with isimip3b data\n"
@@ -2079,28 +2195,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
-   "id": "d3890d00",
+   "execution_count": 38,
+   "id": "5543d216",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-07-07 10:20:17: oggm.workflow: Execute entity tasks [run_from_climate_data] on 2 glaciers\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<oggm.core.flowline.FluxBasedModel at 0x7fd64b727eb0>,\n",
+       " <oggm.core.flowline.FluxBasedModel at 0x7fd64b74a7f0>]"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "y0 = 1850 #79  # this is where the W5E5 climate dataset begins\n",
     "ye = 2100  # and ends\n",
-    "for gdir in gdirs:\n",
-    "    pf = gdir.read_json('local_mustar')['prcp_fac_from_winter_prcp']\n",
-    "    tasks.run_from_climate_data(gdir,\n",
+    "workflow.execute_entity_task(tasks.run_from_climate_data, gdirs,\n",
     "                             min_ys=y0, ye=ye,\n",
     "                             evolution_model=evolution_model,\n",
     "                                climate_filename='gcm_data',\n",
     "                                climate_input_filesuffix=fs,\n",
-    "                             output_filesuffix=f'_gcm_{fs}',\n",
-    "                               precipitation_factor=pf) \n"
+    "                             output_filesuffix=f'_gcm_{fs}')\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 75,
-   "id": "a4f95226",
+   "id": "64f213aa",
    "metadata": {},
    "outputs": [
     {
@@ -2127,21 +2259,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
-   "id": "ef4eb4ca",
+   "execution_count": 39,
+   "id": "5378fef0",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-05-30 17:26:52: oggm.utils: Applying global task compile_run_output on 2 glaciers\n",
-      "2022-05-30 17:26:52: oggm.utils: Applying compile_run_output on 2 gdirs.\n"
+      "2022-07-07 10:20:35: oggm.utils: Applying global task compile_run_output on 2 glaciers\n",
+      "2022-07-07 10:20:35: oggm.utils: Applying compile_run_output on 2 gdirs.\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABIUAAAHwCAYAAAA4m994AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAB7P0lEQVR4nOzdd3hcxfn28fvZVe9dLpJ7r9iWbYwBmxJiIHRCS6hJDOmk/BKSvOm9k0JCCxACodfQSYJMtXHvvcu9SbasLs37h9aOMLIt21rNrvb7ua69vLvn7Dn3zlr26NkzM+acEwAAAAAAAGJLwHcAAAAAAAAAdDyKQgAAAAAAADGIohAAAAAAAEAMoigEAAAAAAAQgygKAQAAAAAAxCCKQgAAAAAAADGIohAAAAAAAEAMoigERDEzW2dm1WZWaWZbzewBM0trsb3EzF4wsz1mVm5mS8zsp2aWHdp+g5m9fcgxrzKzpWa238xWm9lpLbadZWbLzKzKzN4ws55HyJZgZk+GMjozm3zI9jNCx6gws3VteK+HPbc1+6WZ7QrdfmVm1mL7SWb2VuhcZWb2vUNe+x0z22Bme83sUTPLaLF9cah9D9wazOxfR8sLAAA6L/pgx3YsM5sUyvKTFs9NNrOmQ/pZ17fYnmhm94X6Z1vN7KtHywrg2FEUAqLfBc65NEknSRol6VuSZGanSCqV9I6kQc65LElTJDVIGtnagczsI5J+KelGSemSTpe0JrQtT9LTkr4rKUfSLEmPHSXb25I+KWlrK9v2S7pP0v8d7Q224dxTJV0cel8jJH1M0s0ttv9T0puh106S9FkzuzC07TpJ10qaKKmbpGRJfzrwQufcUOdcWqiN0yVtkPTE0TIDAIBOjz5YG45lZvGS/iBpRiubNx/oZ4Vuf2+x7QeS+kvqKekMSd8wsylHywzg2MT5DgCgfTjntprZq2rumEjSryTd75z7eYt9Nkj6/hEO80NJP3LOTQ893tRi26WSFjvnnpAkM/uBpJ1mNsg5t6yVPHWSbg/t29jK9vclvW9mZ7fh7R3t3NdL+q1zriy0/beSPiPpztDre0l62DnXKGl16Ju5oZKel3SBpL855zaGXvtLSf81s88656oOyXG6pAJJT7UhMwAAiAGx3Adr47G+Juk1NfehjsV1km50zu2RtMfM7pF0g6RXjvE4AI6AK4WATsLMiiSdK2mVmaVKmqBjKF6YWVBSiaR8M1sVGmb1ZzNLDu0yVNL8A/s75/ZLWh16PtyOdu4PbA/db5nrdknXmVm8mQ1Uc9v8O7TNQje1eJyo5m+mDnW9pCdD5wcAAIj1PtgRhYaa3STpR4fZpcDMtpnZWjP7faj9FBpm101H7t8BaAcRVxQKjRvdbmaL2rBvj9AY1rlmtsDMzuuIjECEedbM9knaKGm7mr+Fylbzz/fBS4ateZ6d8tA49f/XynEKJcVLulzSafrfpdAH9k2TVHHIayrUfIlzuB3t3Idur5CUZnZwXqEX1Py+qiUtU/OVQTND216W9Gkz62VmmZK+GXo+peXJzCwldIwHTvjdAECEOcb+1+lmNsea51i7/JBt15vZytDt+sMdA+gk6IMd3R8lfdc5V9nKtmVqfq9dJZ0paYyk37U474FzHc95AbRRxBWF1PwLV1vHiv4/SY8750ZJukrSX8IVCohgFzvn0iVNljRIUp6kPZKa1PyfrCTJOfeN0Jj2Z9T60NHq0J9/cs5tcc7tVPN/zAeKrZWSMg55TYakfaEC7cFJAtvnbX3AYc99mO0Zkiqdc87MctR8mfGPJCVJKpb0UTP7XGjf+yQ9ouax/4slvRF6vuyQ810qabekaSf6ZgAgAj2gtve/Nqh5CMc/Wz4Z+vf2+5LGSxon6fuhb/uBzoo+2BGY2QWS0p1zrc5/5Jzb6pxb4pxrcs6tlfQNNRfGDpz3wLmO6bwAjk3EFYWcc2+q+Revg8ysr5m9YmazrXkFoUEHdtf//qHIlLS5A6MCEcU5N03NnfrfhC7tnaHmQkZbX79HzYUQd5hdFqvF5Iihy3v7qnmc+YaWkwQe51s4ksOeu7XtofsHtvWR1Oice9A51xCad+hRhTpaoY7I951zvZxzRaHXbdIHx/JLzUPHHnTOHa59ACBqHUv/yzm3zjm3QM2/+Lb0UUmvO+d2h/5PeV1tLzQBUSvG+2BHcpakktDKYVslXSnpVjN77jD7O4WG9IfaZIsO378D0E4irih0GHdL+qJzboykr+t/VwT9QNInzaxM0kuSvugnHhAxbpf0ETM7Sc3fttxkZreZWYF0cMx77yO8/n5JXzSzgtC3u7eqeeiV1Pzt1jAzu8zMkiR9T9KC1iY4PMCalxJNCj1MMLOkA0O6zCwQ2hbf/NCSzCzhMIc62rkflPRVM+tuZt3UPKHhA6FtK0LHvyZ0zi5q7pTMD+XICf3iY2Y2RM3fzP3IOXfwl51Qu50hqeWKGADQ2R2u/3U43dU8jOaAstBzQCy4XTHYBzvKsb4raYCah4idpOYFPu5R8wprB5ak7xHqgxVL+oWklgWjByX9PzPLDhWlPyOG8QPtLuKLQmaWJukUSU+Y2TxJd+l/l2NeLemB0Lf750n6h5lF/HsCwsU5t0PN/4F+1zn3tprHZ58uaYWZlat5GFWpWiy5fogfS5qp5kLKUklzJf20xbEvCz3eo+bhAVcdJdJyNV8S3V3Sq6H7PUPbTg89fklSj9D91w680MwWm9kn2njuuyT9S9JCSYskvRh6Ts65vWr+tu4rodfOC+3z09Br80IZ9qt5fqH7nHN3H/I+rpX0nnNu9VHeLwB0Ckfpfx32Za08x9WViAkx3Ac77LGcc/tCQ8S2Oue2hrbtd84duCpxtKT31NwHe1fN/bMvtTj299U8qfV6NQ/f/7VzjpXHgHZmkTgSwsx6SXrBOTfMzDIkLXfOfagjYmaLJU1psZT0GkknO+e2d2hgAACAKNfW/leL/R8I7f9k6PHVkiY7524OPb5LUqlz7pGwhwcAAMcl4q+qCX3Lv9bMPi41X5NoZgfGlm5Q81hVmdlgNU8iu8NLUAAAgE7iKP2vw3lV0jmhoR7Zks4JPQcAACJUxF0pZGaPqHkG/zxJ29R82eB/Jf1VzZctx0t61Dn3o9D8H/eoeclCJ+kbzrnXWjsuAAAAWneM/a+xap5nJFtSjaStzrmhoePcJOnbocP+1Dl3f0e+DwAAcGwirigEAAAAAACA8Iv44WMAAAAAAABofxSFAAAAAAAAYlCc7wAt5eXluV69ekmS9u/fr9TUVL+BYhjt7x+fgV+0v1+0v1/hbP/Zs2fvdM7lh+XgOC4t+18SP3++0f5+0f5+0f5+0f7++eiDRVRRqFevXpo1a5YkqbS0VJMnT/YbKIbR/v7xGfhF+/tF+/sVzvY3s/VhOTCOW8v+l8TPn2+0v1+0v1+0v1+0v38++mAMHwMAAAAAAIhBFIUAAAAAAABiEEUhAAAAAACAGBTWopCZZZnZk2a2zMyWmtmEcJ4PAAAAAAAAbRPuiab/IOkV59zlZpYgKSXM5wMAAAAAAEAbhK0oZGYZkk6XdIMkOefqJNWF63wAAAAAAABou3BeKdRH0g5J95vZSEmzJX3ZObe/5U5mNlXSVEkqLCxUaWmpJKmysvLgfXQ82t8/PgO/aH+/aH+/aH8AAIDYEM6iUJyk0ZK+6JybYWZ/kHSbpO+23Mk5d7ekuyWppKTETZ48WZJUWlqqA/fR8Wh///gM/KL9/aL9/aL9AQAAYkM4J5ouk1TmnJsRevykmotEAAAAAAAA8CxsRSHn3FZJG81sYOipsyQtCdf5AAAAAAAA0HbhXn3si5IeDq08tkbSjWE+HwAAAAAAANognMPH5Jyb55wrcc6NcM5d7JzbE87zAQAAdFZmdp+ZbTezRUfZb6yZNZrZ5R2VDQAARKewFoUAAADQbh6QNOVIO5hZUNIvJb3aEYEAAEB0oygEAAAQBZxzb0rafZTdvijpKUnbw58IAABEO4pCAAAAnYCZdZd0iaQ7fWcBAADRIdwTTQMAAKBj3C7pm865RjM74o5mNlXSVEkqLCxUaWnpwW2VlZUfeIyORfv7Rfv7Rfv7Rfv75+MziNmikHNOR+swAQAARJESSY+G+jd5ks4zswbn3LOH7uicu1vS3ZJUUlLiJk+efHBbaWmpWj5ub41NTsEAfbDDCXf748hof79of79of/98fAYxN3ysscnpl68s08gfvqa1O/f7jgMAANAunHO9nXO9nHO9JD0p6XOtFYR8qaxt0E0PzNQZvynVzspa33EAAIBirChUUVWvmx6Yqb+WrtbemgY9M6fMdyQAAIA2MbNHJL0naaCZlZnZp8zsFjO7xXe2o9laUaOP3/mepq3Yoa17a/SFf85RQ2OT71gAAMS8mBk+tmLbPn3mwVnaXF6tn10yXC8u3Kzn52/WVz4ygGFkAAAg4jnnrj6GfW8IY5RjsnTLXt30wEztq2nQfTeM1a7KWn318fn65SvL9J3zh/iOBwBATIuJotAri7boq4/PV2pinB6derLG9MxRMCB986mFWrRpr4YXZfqOCAAA0Om8uWKHPvfwHKUlxunxmydoSLcMSdK8jeW65621GlGUpQtGdvOcEgCA2NXph48t2bxXtzw0R/0L0/WvL5yqMT1zJElThnZVfND0/PxNnhMCAAB0Pv+av1k3PTBTRdnJeubzpxwsCEnS/zt/iMb0zNY3n1qg5Vv3eUwJAEBs6/RFoSHdMvTHq0fpsaknq0tm0sHnM1PiNWlAvl5YsEVNTc5jQgAAgM5ncNd0TRnWRU/cMkFdM5M/sC0hLqC/fGK0UhPjdMtDs1VRXe8pJQAAsa3TF4Uk6cKR3ZQUH/zQ8xeM7KYtFTWatX6Ph1QAAACdV7+CdP35mtFKT4pvdXthRpLuuGa0Nu6u0neeWdjB6QAAgBQjRaHDOXtwoZLiA/rX/M2+owAAAMSccb1z9IUz++mFBVs0Y80u33EAAIg5MV0USk2M01mDC/XSwi0siwoAAODBzaf3VdfMJP34xSUM6QcAoIPFdFFIah5atmt/nd5dzbdTAAAAHS05Iajbzh2kRZv26qk5Zb7jAAAQU2K+KDRpQL7SE+P0PEPIAAAAvLhwZDedVJylX726XPtrG3zHAQAgZsR8USgpPqhzhnbRq4u2qrah0XccAACAmGNm+t4FQ7RjX63unLbadxwAAGJGzBeFJOnCk7ppX22DSpfv8B0FAAAgJo3uka2LTuqmu99co7I9Vb7jAAAQEygKSTqlb65yUhNYhQwAAMCjb04ZJDPpl68s9x0FAICYQFFIUnwwoHOHddF/lm5XXQOrkAEAAPjQLStZU0/ro3/N36wnZ5cxtB8AgDCjKBRyWv98Vdc3atHmCt9RAAAAYtbNk/qqb36qvv7EfI39yb/1racXaPqaXSxXDwBAGMT5DhApSnplS5Jmrdut0T2yPacBAACITamJcXr11tP19qqdem7eZj03b7MeeX+jumUm6TvnD9H5I7r6jggAQKdBUSgkLy1RffJSNXPdHk093XcaAACA2BUXDGjywAJNHligqroGvb5km/729lp9/p9zVLq8SN+/cKjSEunGAgBwovjftIWSXtl6fck2NTU5BQLmOw4AAEDMS0mI00Unddd5w7vqD/9eqTtKV+n9dbv1h6tG6aTirKO+fs/+Oq3ZWan1u6q0fleVNuyu0ubyan28pFiXjykK/xsAACCCURRqoaRXjh6fVaY1OyvVryDddxwAAACExAcD+vpHB+q0/nn6ymPzdPlf39XU0/uoX0Ga4oMBJcQFlBAMqLK2QUu37A3d9mnr3pqDxzCTumUmKyEuoK8/MV9NTU5XjC32+K4AAPCLolALY3vlSJJmrttDUQgAACACje+Tq5e/fLq+/exC/aV0dav7xAVM/QrSNKFvrgZ1SVf/wjT1zE1VUXayEuOCqqlv1GcenKVvPr1AifEBXXRS9w5+FwAARAaKQi30yk1RXlqCZq7bravH9fAdBwAAAK3ITInXHdeM1vc/VqOqukbVNzaprrFJ9Y1OiXEB9clPVWJc8LCvT4oP6u5rS3TTAzP11cfnKz4Y0HnDmcAaABB7KAq1YGYq6ZmjWev2+I4CAACAoyjISDru1yYnBHXv9SW6/r739aVH5io+GNBHhhS2YzoAACJfwHeASFPSK1sbdldpW4vx5wAAAOh8UhPjdP+NYzW0e6Y+//Ac/f71FSqvqvMdCwCADkNR6BAH5hXiaiEAAIDOLz0pXg/eOE5nDirQH/6zUhN/8V/9/KWl2r6PLwgBAJ0fRaFDDOmWoeT4oGau2+07CgAAADpAZkq87rx2jF699XSdPaRQ97y1Rqf98g394PnFqq5r9B0PAICwoSh0iPhgQKN6ZGnWeopCAAAAsWRgl3T94apR+u/XJuuSUd319/fW6br7Zqiiut53NAAAwoKiUCtKeuVoyea9qqxt8B0FAAAAHaxXXqp+cdkI/fnq0Zq3sVxX3vUew8kAAJ0SRaFWjO2VrSYnzd3AvEIAAACx6vwRXXXfDWO1YXeVPn7ne9qwq8p3JAAA2hVFoVaM6pGtgEkzmWwaAAAgpp3WP18Pf3q8Kqrrddmd72rplr2+IwEA0G4oCrUiLTFOQ7plaBaTTQMAAMS8UT2y9fjNExQw6ZP3ztDeGuYYAgB0DhSFDqOkZ47mbihXfWOT7ygAAADwbEBhuv52/Vjt2l+nu6at9h0HAIB2QVHoMMb2ylF1faOWbOYSYQAAAEjDumfqwpHd9Le312r7XiaeBgBEP4pCh1HSK1uSNJMhZAAAAAj52jkD1NDodPt/VvqOAgDACaModBiFGUnqkZOiGWspCgEAAKBZz9xUfWJ8Dz02c6NW76j0HQcAgBNCUegIpgzron8v3cbVQgAAADjoi2f1V1JcQL95dbnvKAAAnBCKQkfw5bP6qyg7Wf/3xHxV1zX6jgMAAIAIkJeWqM+c3kcvL9qquRv2+I4DAMBxoyh0BKmJcfrVZSO1bleVfs03QQAAAAj59Gl9lJeWoF+8vEzOOd9xAAA4LhSFjmJC31xdN6Gn7n93rd5nfiEAAABISkuM0xfP7K8Za3erdMUO33EAADguFIXa4JtTBqkoO1nfeJJhZAAAAGh29bge6pGToj+yEhkAIEpRFGoDhpEBAADgUAlxAV17ck/N3VCuVdtZiQwAEH0oCrURw8gAAABwqItGdVMwYHpqTpnvKAAAHDOKQsfgm1MGqVtmsn760lImFAQAAIAK0pM0aUC+npmzSY1N9A8BANGFotAxSE2M0+fO6Kv5G8v1zqpdvuMAAAAgAlw2ukhb99bonVU7fUcBAOCYUBQ6RpePKVJhRqL+/AYTCgIAAEA6a3CBMpPjGUIGAIg6FIWOUWJcUFNP76vpa3Zr1jrmFgIAAIh1SfFBXTCyq15ZtFV7a+p9xwEAoM0oCh2Hq8cVKyc1QX9+Y5XvKAAAAIgAl48pVm1Dk15asMV3FAAA2oyi0HFISYjTp07trdLlO7RoU4XvOAAAAPBsZFGm+uan6snZDCEDAEQPikLH6doJPZWeFKc//5erhQAAAGKdmemyMUWatX6P1u3c7zsOAABtQlHoOGUkxeuGU3rplcVbtWLbPt9xAAAA4Nmlo4oUMOlpJpwGAEQJikIn4MaJvZWSENRfmFsIAAAg5nXJTNLEfnl6as4mNTU533EAADgqikInICc1QZ8Y30PPz9+sFxZsVkUVq00AAIDwMLP7zGy7mS06zPZPmNmC0O1dMxvZ0RkhXT6mSJvKqzV97S7fUQAAOCqKQifoM6f1UW5aor7wz7k66cev6fw/vqUfv7BE01bskHN8QwQAANrNA5KmHGH7WkmTnHMjJP1Y0t0dEQof9NGhXZSZHK8fPL9Yu/fX+Y4DAMARURQ6QQUZSXr7m2fo8Zsn6NazBigjKV7/mL5e19/3vv46bbXveAAAoJNwzr0pafcRtr/rnNsTejhdUlGHBMMHJMUH9ddPjNb6XVW69m8zVFHNleQAgMhFUagdJMYFNa53jr58dn89MvVkLfj+ObpgZDf96pXlemXRVt/xAABA7PmUpJd9h4hVp/TL013XjtGKbft0w/3vq7K2wXckAABaFRfOg5vZOkn7JDVKanDOlYTzfJEiKT6oX18+Qht2V+krj81TUfYEDeue6TsWAACIAWZ2hpqLQqceYZ+pkqZKUmFhoUpLSw9uq6ys/MBjHL9bRiTojnnluuz21/XVkiQlBu2or6H9/aL9/aL9/aL9/fPxGYS1KBRyhnNuZwecJ6IkxQd1z7VjdNEd7+gzD87Sc5+fqIKMJN+xAABAJ2ZmIyTdK+lc59xhZzp2zt2t0JxDJSUlbvLkyQe3lZaWquVjHL/JkgYM2qwvPzpX/1ibonuvL1FSfPCIr6H9/aL9/aL9/aL9/fPxGTB8LIwKMpJ07/Ulqqiu12cenKWa+kbfkQAAQCdlZj0kPS3pWufcCt950OyCkd30q8tH6u1VO/W5h+eorqHJdyQAAA4K95VCTtJrZuYk3RX6VuoDDnf5cme6dO3TQ+P0p7kV+sSfX9fNIxKV0IZLh33rTO0frfgM/KL9/aL9/aL9I5OZPaLmi0/yzKxM0vclxUuSc+5OSd+TlCvpL2YmxdDQ/Uh3+Zgi1TU06dvPLNQX/jlHd3xitOKDfDcLAPAv3EWhic65zWZWIOl1M1sWWjnjoMNdvtyZLl2bLCmj2xr95MWl+tX8gG6/8qSIn2OoM7V/tOIz8Iv294v294v2j0zOuauPsv3Tkj7dQXFwjK4Z30P1jU36/vOLdeuj8/SHq05SHIUhAIBnYf2fyDm3OfTndknPSBoXzvNFsk+f1kcP3jRO+2rqdfEd7+iON1apscn5jgUAAIAOcv0pvfT/zh+sFxdu0defmE9fEADgXdiKQmaWambpB+5LOkfSonCdLxqcPiBfr956uj46rIt+/epyXXHXe9qwq8p3LAAAAHSQT5/WR9+YMlDPztusbz61QE0UhgAAHoXzSqFCSW+b2XxJ70t60Tn3ShjPFxWyUhL056tH6fYrT9KKbft0w/3v0xkAAACIIZ+b3E9fOXuAnpxdpi8/No/JpwEA3oRtTiHn3BpJI8N1/GhmZrp4VHcFA6YvPjJXpSu268xBhb5jAQAAoIN8+ez+SooP6OcvL1NFdb3u/ORopSSEe7pPAAA+iNntPJoyrIsKMxL1wLvrfUcBAABAB7t5Ul/96rIRenvlDn3i3hkqr6rzHQkAEGMoCnkUHwzok+N76s0VO7Rqe6XvOAAAAOhgV4wt1l8+MUaLN+3VFXe9pz01DCUDAHQcikKeXT2+hxKCAT343jrfUQAAAODBlGFd9MBNY7VpT7V+Mr2GLwsBAB2GopBneWmJumBkNz05u0x7a+p9xwEAAIAHp/TN06NTJ6i+yenyO9/V7PW7fUcCAMQAikIR4IZTeqmqrlFPzirzHQUAAACeDC/K1P87OVlZyfG65p4ZenXxVt+RAACdHEWhCDC8KFNjembr7++tY3l6AACAGFaQEtBTnz1Fg7pm6LMPzdY/mGIAABBGFIUixA2n9NL6XVUqXbHddxQAAAB4lJuWqEc+M15nDCzQd59brD/+Z6XvSACAToqiUIQ4sDz9/e+s8x0FAAAAnqUkxOmua8fo0lHd9bvXV+g/S7f5jgQA6IQoCkWIA8vTv7VyJytOAAAAQHHBgH526XAN7Zahrz0xX5vKq31HAgB0MhSFIsiB5envmrbadxQAAABEgKT4oO64ZrQaGp2+8M85qmto8h0JANCJUBSKIHlpibpxYi89MbtM769lGVIAAABIvfJS9cvLRmjuhnL9+tVlvuMAADoRikIR5stn91f3rGR9+5mFqm1o9B0HAAAAEeD8EV113YSeuuettXp9CfMLAQDaB0WhCJOSEKefXDJMq7ZX6q5pa3zHAQAAQIT4zvmDNax7hr72+Dxt3F3lOw4AoBOgKBSBzhhYoI+N6Ko/v7FKa3Yw6TQAAACkxLjm+YWckz7/zzlcVQ4AOGEUhSLU9y4YosS4gL7zzCI553zHAQAAQATomZuq314xUgvKKvSjfy3xHQcAEOUoCkWogvQk3XbuIL23ZpeenF3mOw4AAAAixDlDu+iWSX318IwNeop+IgDgBFAUimBXj+2hkp7Z+ulLS7WrstZ3HAAAAESIr58zQCf3ydF3nl2opVv2+o4DAIhSFIUiWCBg+tmlw7W3ul73vbPWdxwAAABEiLhgQH+6erQykuL12Ydma29Nve9IAIAoRFEowg0oTNfkgQV6cnaZGhqbfMcBAABAhMhPT9RfPjFaZXuq9X9PzGceSgDAMaMoFAWuHFusbXtrNW3FDt9RAAAAEEFKeuXoW+cN1quLt+kf09f7jgMAiDIUhaLAmYMKlJeWqEdnbvQdBQAAABHmpom9dPqAfP3y5WUq21PlOw4AIIpQFIoC8cGALhvTXf9dtl3b99X4jgMAAIAIYmb62SXD5CR955lFDCMDALQZRaEocWVJsRqbnJ6avcl3FAAAAESYouwUfeOjAzVtxQ49M5f+IgCgbSgKRYk++Wka1ytHj8/ayLc/AAAA+JBrJ/TSmJ7Z+tELS7SzstZ3HABAFKAoFEWuHFustTv36/21u31HAQAAQIQJBky/vGy4qmob9YPnF/uOAwCIAhSFosh5w7sqPTFOjzHhNAAAAFrRryBdXzyzn15YsEWvLd7qOw4AIMJRFIoiyQlBXXhSN720aIsqqut9xwEAAEAEunlSXw3qkq7vPreIPiMA4IgoCkWZq8b2UE19k56fv9l3FAAAAESghLiAfnX5CO3YV6ufvbjUdxwAQASjKBRlhnXP0OCuGXps5gbfUQAAABChRhRlaerpffXYrI16c8UO33EAABGKolCUMTNdNbZYizbt1dIte33HAQAAQIS69ez+6pufqm89vVCVtQ2+4wAAIhBFoSh07vAukqT/LtvuOQkAAAAiVVJ8UL+6fKQ2V1Tr5y8xjAwA8GEUhaJQQXqShnXP0BsUhQAAAHAEY3pm61MTe+vhGRv07uqdvuMAACIMRaEodcbAAs3ZsEflVXW+owAAACCCfe2cgeqVm6LbnlqoqjqGkQEA/oeiUJSaPLBATU56ayXf+AAAAODwkhOah5Ft3FOlX72y3HccAEAEoSgUpU4qzlJWSrzeWM4QMgAAABzZuN45un5CLz3w7jo9ObvMdxwAQISI8x0AxycYMJ3eP1/Tlu9QU5NTIGC+IwEAACCCffu8wVq1vVLffGqBctMSdMbAAt+RAACecaVQFDtjUL527a/Tos0VvqMAAAAgwiXEBfTXT47WoC7p+txDczR/Y7nvSAAAzygKRbHT++fLTHpj2Q7fUQAAABAF0pPidf+NY5WXnqCbHpiptTv3+44EAPCIolAUy01L1IiiLOYVAgAAQJsVpCfp7zeOk5N03X0ztGNfre9IAABPKApFuTMG5mt+Wbl272dpegAAALRNn/w03XfDWO3cV6fPPjRbzjnfkQAAHlAUinKTBxbIOenNFQwhAwAAQNudVJylH144VLPW79Gz8zb5jgMA8ICiUJQb0T1TuakJDCEDAADAMbt8TJFGFmXqFy8v0/7aBt9xAAAdjKJQlAsETJMG5OvNFTvU2MRlvwAAAGi7QMD0vQuGatveWv2ldJXvOACADkZRqBOYNDBfe6rqNb+s3HcUAAAARJkxPbN1yajuuuettdqwq8p3HABAB6Io1Amc3j9fAZNKlzGEDACAzsrM7jOz7Wa26DDbzcz+aGarzGyBmY3u6IyIXredO0hxAdNPXlziOwoAoANRFOoEslMTNKpHtkqZbBoAgM7sAUlTjrD9XEn9Q7epkv7aAZnQSRRmJOnzZ/TTa0u26e2VO33HAQB0EIpCncTp/fO1oKxC+2rqfUcBAABh4Jx7U9LuI+xykaQHXbPpkrLMrGvHpENn8KlTe6tHTop+9MJiNTQ2+Y4DAOgAFIU6icFd0yVJq7ZXek4CAAA86S5pY4vHZaHngDZJig/qO+cP1optlbr/nXW+4wAAOkCc7wBoHwMKm4tCK7dValSPbM9pAACAB9bKc60uTWpmU9U8xEyFhYUqLS09uK2ysvIDj9GxfLd/gnMaVRDUz19eqrrtazU0L+gtiw++2z/W0f5+0f7++fgMKAp1EsU5KUqMC2jFtn2+owAAAD/KJBW3eFwkaXNrOzrn7pZ0tySVlJS4yZMnH9xWWlqqlo/RsSKh/Usm1Ovyv76nuxZV65nPj1ff/DSveTpSJLR/LKP9/aL9/fPxGTB8rJMIBkz9CtK0guFjAADEquclXRdahexkSRXOuS2+QyH6pCfF697rSxQfDOjTf5+l8qo635EAAGFCUagT6V+QplVcKQQAQKdkZo9Iek/SQDMrM7NPmdktZnZLaJeXJK2RtErSPZI+5ykqOoHinBTdee0YbdpTrc89PEf1TDwNAJ0Sw8c6kf6F6Xp23mbtq6lXelK87zgAAKAdOeeuPsp2J+nzHRQHMWBsrxz97NLh+voT8/X95xfrpxcPk1lrU1cBAKIVVwp1Igcnm2YIGQAAANrB5WOKdMukvvrnjA16bl6rU1QBAKIYRaFOpH9B8ySAKxlCBgAAgHbyjY8O1PDumfrNa8tV18AwMgDoTCgKdSIHViBbuY0rhQAAANA+AgHT184ZoLI91Xps1kbfcQAA7YiiUCfCCmQAAAAIh0kD8jWuV47+9J+Vqq5r9B0HANBOKAp1MgMK0xk+BgAAgHZlZvr6Rwdq+75aPfjeOt9xAADthKJQJ9OvIE1bKmq0t6bedxQAAAB0IuN652jywHz9ddpq+poA0ElQFOpkDqxAtoohZAAAAGhnXz9noMqr6nXvW2t9RwEAtIOwF4XMLGhmc83shXCfC9KAQlYgAwAAQHgM656p84Z30d/eWqNdlbW+4wAATlBHXCn0ZUlLO+A8kFSUnaKk+IBWsAIZAAAAwuCrHxmg6vpG/bV0te8oAIATFNaikJkVSTpf0r3hPA/+Jxgw9c1P0wquFAIAAEAY9CtI1yWjivTg9PUq21PlOw4A4ATEhfn4t0v6hqT0w+1gZlMlTZWkwsJClZaWSpIqKysP3sexyVCNFm/cd0LtR/v7x2fgF+3vF+3vF+0P4Gi+8pH+emnhFn3/ucW69/oSmZnvSACA4xC2opCZfUzSdufcbDObfLj9nHN3S7pbkkpKStzkyc27lpaW6sB9HJslWqX3Xlmu0SdPVEZS/HEdg/b3j8/AL9rfL9rfL9ofwNEUZafoKx/pr5+9tEwvL9qq84Z39R0JAHAcwjl8bKKkC81snaRHJZ1pZg+F8XwIGVDQfGHWSuYVAgAAQJjcNLG3hnTN0A+eX8wS9QAQpcJWFHLOfcs5V+Sc6yXpKkn/dc59Mlznw//0ZwUyAAAAhFlcMKBfXDZcOytr9atXlvmOAwA4Dh2x+hg6WHFoBbKV27lSCAAAAOEzoihL15/SSw/P2KDZ6/f4jgMAOEYdUhRyzpU65z7WEeeCFAiY+hWwAhkAAADC72vnDFTXjCR9++mFqmto8h0HAHAMuFKok+pfkM6cQgAAAAi7tMQ4/eiiYVq+bZ/ueWuN7zgAgGNAUaiT6l+Ypq17a1RRzaR/AAAACK+zhxTq3GFd9Mf/rNSe/XW+4wAA2oiiUCd1YAWyVcwrBAAAgA7wpbP6q7ahSU/P3eQ7CgCgjSgKdVIDCg8sS8+8QgAAAAi/wV0zNKpHlh55f4Occ77jAADagKJQJ1WUnayk+IBWMK8QAAAAOsjV43po1fZKzWIlMgCIChSFOqkDK5Ct3M6VQgAAAOgYHxvRVemJcXpkxgbfUQAAbUBRqBMbVZyt99fu1s7KWt9RAAAAEANSEuJ08ajuemHhFpVXMeE0AEQ6ikKd2A0Te6musUkPvLPOdxQAAADEiKvH9VBdQ5OeYcJpAIh4FIU6sb75afrokC568L11qqxt8B0HAAAAMWBItwyNLGbCaQCIBhSFOrlbJvfV3poGxnUDAACgw1wzrlgrtlVqNhNOA0BEoyjUyZ1UnKUJfXL1t7fXqq6hyXccAAAAxICPjeimtMQ4/fN9vpgEgEhGUSgG3DK5r7burdGz8xjXDQAAgPBLTYzTRSd104sLtqiiqt53HADAYVAUigGn98/TkK4ZumvaajU1Ma4bAAAA4Xf1uB6qbWjSM3PLfEcBABwGRaEYYGa6eVIfrd6xX68v3eY7DgAAAGLAsO6ZGlGUqfveWaea+kbfcQAAraAoFCPOH95VxTnJunPaalaBAAAAQIe4bcogbdhdpd+/vsJ3FABAKygKxYi4YEBTT+ujuRvK9f7a3b7jAAAAIAac0i9PV48r1j1vrdH8jeW+4wAADtHmopCZpZpZMJxhEF4fLylWbmqC7nlrje8oAADEPPpWiBXfOm+wCtKT9I0nF7AaLgBEmMMWhcwsYGbXmNmLZrZd0jJJW8xssZn92sz6d1xMtIek+KCuHtdD/1m2XRt3V/mOAwBATKFvhViVkRSvn14yTMu37dMdb6zyHQcA0MKRrhR6Q1JfSd+S1MU5V+ycK5B0mqTpkn5hZp/sgIxoR9eM7yGT9M/3N/iOAgBArKFvhZh11uBCXXxSN93xxiot27rXdxwAQMiRikJnO+d+7Jxb4Jw7eJ2nc263c+4p59xlkh4Lf0S0p25ZyTp7cKEem7mRVSAAAOhY9K0Q0753wVBlJsfrG08uUEMjw8gAIBIctijknKs/9DkzyznaPoh8103opd376/TSwi2+owAAEDPoWyHW5aQm6IcXDdWCsgr9pXS17zgAAB15TqGJZrY0NM59vJm9LmmWmW00swkdmBHtbGK/XPXJT9U/pq/3HQUAgJhB3wqQzh/eVRef1E2/e32Fnp27yXccAIh5Rxo+9ntJV0j6tKQXJf3QOddH0kWSftMB2RAmZqZrT+6puRvKtWhThe84AADECvpWiHlmpl9ePkIn98nR/z05X2+v3Ok7EgDEtCMVheKdcwudc+9J2uGce1uSnHNzJCV3SDqEzaWji5QcH9SD763zHQUAgFhB3wqQlBgX1F3XlqhPXppueWi2Fm/mS0oA8OVIRaGW2751yLaEMGRBB8pMjtfFo7rruXmbVV5V5zsOAACxgL4VEJKZHK8Hbhqr9KQ43XD/TJXtqfIdCQBi0pGKQt81sxRJcs49e+BJM+sr6cEw50IHuPbknqptaNKTs8t8RwEAIBbQtwJa6JqZrL/fNE619Y26/r73+aISADw40upjzzvnPlSyd86tds79Kryx0BGGdMtQSc9s/WP6ejU1Od9xAADo1OhbAR82oDBd91xXoo27q/WNJxfIOfqkANCRjnSlkCTJzErM7Bkzm2NmCw7cOiIcwu/aCT21fleV3ly5w3cUAABiAn0r4IPG98nV/310oF5bsk1PzOIKdgDoSHFt2OdhSf8naaGkpvDGQUc7d1hX/SR9qe5/Z50mDyzwHQcAgFhA3wo4xKdO7a3/LNumH/5rsU7uk6seuSm+IwFATDjqlUJqXh3jeefcWufc+gO3sCdDh0iIC+jak3tq2oodWrV9n+84AADEAvpWwCECAdNvrzhJgYDpq4/PUyNTGwBAh2hLUej7ZnavmV1tZpceuIU9GTrMJ8b3UEJcQPe9s853FAAAYgF9K6AV3bOS9eOLhmnW+j26c9pq33EAICa0ZfjYjZIGSYrX/y5xdpKeDlcodKzctERdclJ3PT2nTP93zkBlp7IqLgAAYUTfCjiMi07qpteXbtPvX1+h0/vna3hRpu9IANCpteVKoZHOuRLn3PXOuRtDt5vCngwd6sZTe6mmvkmPzNzgOwoAAJ3dcfetzGyKmS03s1Vmdlsr2zPN7F9mNt/MFpvZje0fHwgfM9NPLx6mvLRE3frYXJapB4Awa0tRaLqZDQl7Eng1qEuGTu2XpwffXa/6Rua8BAAgjI6rb2VmQUl3SDpX0hBJV7dynM9LWuKcGylpsqTfmhmXACOqZKUk6LdXjNT6XVWacvtbenf1Tt+RAKDTaktR6FRJ80LfSi0ws4Usm9o53XRqL23dW6OXFm7xHQUAgM7sePtW4yStcs6tcc7VSXpU0kWH7OMkpZuZSUqTtFtSQ3uGBzrCxH55euZzE5WSENQn7p2hn7+8VHUNfHEJAO2tLXMKTQl7CkSEyQMK1CcvVfe9vVa3DmXFBwAAwuR4+1bdJW1s8bhM0vhD9vmzpOclbZaULulK5xy/SSMqDS/K1AtfOlU/fmGp7pq2Ru+s2qnbrxylfgVpvqMBQKdx2KKQmaU55yqPtETqgX3CEw0dLRAw3Tixl7773GKt6p6kM3wHAgCgE2mHvpW18tyh3+J8VNI8SWdK6ivpdTN7yzm395DzTJU0VZIKCwtVWlp6cFtlZeUHHqNj0f4f9tEcKW9Uou5ftFcX/HGafjIxWbnJbRnwcOxof79of79of/98fAZHulLoOTObJ+k5SbOdc/slycz6SDpD0hWS7pH0ZLhDouNcOrpIv351uV5bX6/P+A4DAEDncqJ9qzJJxS0eF6n5iqCWbpT0C+eck7TKzNaqeaWz91vu5Jy7W9LdklRSUuImT558cFtpaalaPkbHov1bN1nS5Wfv15Tb39IrOzJ0z3UlYTkP7e8X7e8X7e+fj8/gsCV259xZkv4j6WZJi82swsx2SXpIUhdJ1zvnKAh1MqmJcbp6XA/N2tqoTeXVvuMAANBptEPfaqak/mbWOzR59FVqHirW0gZJZ0mSmRVKGihpTfu+E8CPnrmp+vLZ/fX6km16dfFW33EAoFM44pxCzrmXJL3UQVkQIa6d0FN3v7lGj8/cqK98ZIDvOAAAdBon0rdyzjWY2RckvSopKOk+59xiM7sltP1OST+W9ICZLVTzcLNvOudYugmdxqdO7a1n527SD55frIn98pSW2JYpUgEAhxOewbiIakXZKRqSG9CTs8vU2MSE0wAARArn3EvOuQHOub7OuZ+GnrszVBCSc26zc+4c59xw59ww59xDfhMD7Ss+GNBPLxmurXtr9PvXV/iOAwBRj6IQWnV6Ubw2lVfrnVV8uQgAAIDIMaZntq4Z10P3v7NWizZV+I4DAFGNohBaNbowqKyUeD02a+PRdwYAAAA60DemDFJOaqK+/cxCrmwHgBPQpqKQmZ1qZjeG7uebWe/wxoJv8QHTxSd11+uLt2nP/jrfcQAA6FToWwEnJjM5Xt+7YIgWlFXowffW+Y4DAFHrqEUhM/u+pG9K+lboqXg1r5KBTu6KkmLVNTbp2XmbfEcBAKDToG8FtI8LRnTV6QPy9atXlmvNjkrfcQAgKrXlSqFLJF0oab/UPIGhpPRwhkJkGNItQ8O7Z+qxmRvlHJflAgDQTuhbAe3AzPTLy4YrIS6gWx+bp/rGJt+RACDqtKUoVOeaKwJOkswsNbyREEmuGFusZVv3aSGT+AEA0F7oWwHtpGtmsn5x6XAtKKvQ7f9mNTIAOFZtKQo9bmZ3Scoys89I+reke8IbC5HiwpHdlBgX0ONMOA0AQHuhbwW0o3OHd9WVJcX6S+lqzVizy3ccAIgqRy0KOed+I+lJSU9JGijpe865P4U7GCJDZnK8zhveVc/N26ya+kbfcQAAiHr0rYD2970LhqhnToq+8tg8VVTV+44DAFGjTauPOedel/RjST+TNNvMcsKaChHlipJi7atp0MuLtviOAgBAp0DfCmhfqYlx+sNVo7R9X62+/exC5sMEgDZqy+pjN5vZNkkLJM2SNDv0J2LE+N456pGTosdmMoQMAIATRd8KCI+RxVn6ykcG6MUFW/TErDLfcQAgKsS1YZ+vSxrqnNsZ7jCITIGA6YqSIv3mtRXasKtKPXJTfEcCACCa0bcCwuSWSX317uqd+vYzC5WTmqCzhxT6jgQAEa0tw8dWS6oKdxBEtktHF8lMenou37oAAHCC6FsBYRIMmO785BgN6Zahz/1zjt5dRe0VAI6kLUWhb0l618zuMrM/HriFOxgiS7esZJ3SN1dPzSlTUxNjtAEAOAH0rYAwSk+K199vHKdeuSn69IOzNHfDHt+RACBitaUodJek/0qaruYx7wduiDGXjS7Sxt3Vmrlut+8oAABEM/pWQJhlpybooU+NV356om64f6aWbtnrOxIARKS2FIUanHNfdc7d75z7+4Fb2JMh4kwZ1kWpCUE9NYchZAAAnAD6VkAHKMhI0kOfGq/k+KCu/dv7Wr9rv+9IABBx2lIUesPMpppZVzPLOXALezJEnJSEOJ07vKteWrhV1XWNvuMAABCt6FsBHaQ4J0UPfXq86hub9KVH5qq+scl3JACIKG0pCl2j0Nh3/e/yZpZNjVGXjS5SZW2DXl281XcUAACiFX0roAP1K0jTzy8drvllFfrTf1f5jgMAEeWoS9I753p3RBBEh/G9c9Q9K1lPzSnTxaO6+44DAEDUoW8FdLzzhnfVpaO66443VmnywHyN7pHtOxIARISjFoXM7LrWnnfOPdj+cRDpAgHTZaO7609vrNKWimp1zUz2HQkAgKhC3wrw4wcXDdWMtbv11cfm6cUvnabUxKP+KgQAnV5bho+NbXE7TdIPJF14tBeZWZKZvW9m881ssZn98ISSImJcOrpIzknPzN3kOwoAANHouPpWAE5MRlK8fnvFSK3fXaWfvLjUdxwAiAhtGT72xZaPzSxT0j/acOxaSWc65yrNLF7S22b2snNu+vFFRaTolZeqkp7Zemp2mT47qa/MzHckAACixgn0rQCcoJP75GrqaX1015trdPbgAp01uNB3JADwqi1XCh2qSlL/o+3kmlWGHsaHbu44zocIdNmYIq3esV/zyyp8RwEAINq1qW8FoH189ZwBGtQlXd98aoF2Vtb6jgMAXh21KGRm/zKz50O3FyQtl/RcWw5uZkEzmydpu6TXnXMzTigtIsb5I7oqMS6gp2aX+Y4CAEBUOZG+FYATlxgX1O1XnaS91Q36f88sknN8bw0gdrVldrXftLjfIGm9c65NlQDnXKOkk8wsS9IzZjbMObeo5T5mNlXSVEkqLCxUaWmpJKmysvLgfXS8trT/yDzTM7PXa1LGDsUFGELW3vgZ8Iv294v294v2D7vj7lsBaB+DumToq+cM0C9eXqZn523SJaOKfEcCAC/aMqfQtBM9iXOu3MxKJU2RtOiQbXdLuluSSkpK3OTJkyVJpaWlOnAfHa8t7V+Tt1W3PDRbicXDdFr//I4JFkP4GfCL9veL9veL9g+v9uhbAThxnzmtj/69ZJu+99xindwnl1V1AcSkww4fM7N9Zra3lds+M9t7tAObWX7oCiGZWbKksyUta7fk8G7ywHylJgT10sItvqMAABDxTrRvBaB9BQOm33x8pBoanb7x5AKGkQGISYctCjnn0p1zGa3c0p1zGW04dldJb5jZAkkz1Tyn0AvtFRz+JcUHdebgQr26eJsaGpt8xwEAIKK1Q98KQDvrlZeqb58/WG+t3KmHZmzwHQcAOlxb5hSSmY2UdFro4ZvOuQVHe01on1EnkA1R4PzhXfSv+Zs1fc1undo/z3ccAACiwvH0rQCExyfH99Bri7fqZy8u1Q9OTvAdBwA6VFtWH/uypIclFYRuD5vZF8MdDNFh8sACpSQE9SJDyAAAaBP6VkBkMTP96vIRigua7llYq5r6Rt+RAKDDHLUoJOlTksY7577nnPuepJMlfSa8sRAtkuKDOnNQgV5dvJUhZAAAtA19KyDCdM1M1s8uGa5V5U266YGZ2l/b4DsSAHSIthSFTFLLcnlj6DlAknT+8K7avb9OM9bu9h0FAIBoQN8KiEAXjOymzwxP0PQ1u3Tt32aoorredyQACLu2FIXulzTDzH5gZj+QNF3S38KaClFl8sACJcczhAwAgDaibwVEqInd4/WXT4zWwk0Vuvru6dpVWes7EgCE1VGLQs6530m6UdJuSXsk3eicuz3MuRBFkhOCOnNwgV5dxBAyAACOhr4VENmmDOuqe64r0eodlbrirve0taLGdyQACJu2TDT9B0lJzrk/Ouf+4Jyb2wG5EGXOH95Vu/bX6X2GkAEAcET0rYDIN3lggR68aZy27a3VZX99V4s3V/iOBABh0ZbhY3Mk/T8zW2VmvzazknCHQvQ5gyFkAAC0FX0rIAqM75OrR6eerMYmp8v++q5eWLDZdyQAaHdtGT72d+fceZLGSVoh6ZdmtjLsyRBVkhP+twpZY5PzHQcAgIhF3wqIHsO6Z+r5L07UkK4Z+sI/5+o3ry5XE31dAJ1IW64UOqCfpEGSeklaFpY0iGrnDe+qnZV1mrF2l+8oAABEA/pWQBQoSE/SI1NP1hUlRfrzG6s09R+zta+GlckAdA5tmVPowLdXP5K0SNIY59wFYU+GqHPGoHwlxQf0yqKtvqMAABCx6FsB0ScxLqhfXjZCP7hgiN5Yvl1Tbn9L/1m6zXcsADhhcW3YZ62kCc65neEOg+iWkhCncb1zmWwaAIAjo28FRCEz0w0Te2tY90x96+mF+tTfZ2nK0C76/oVD1DUz2Xc8ADgubZlT6E46LWirUcVZWrFtnyprG3xHAQAgItG3AqJbSa8cvfil0/SNKQNVumK7zv7tNN371ho1NDb5jgYAx+xY5hQCjmpUjyw1OWlBWbnvKAAAAEBYJMQF9LnJ/fT6VyZpXO8c/eTFpbr6nunaXF7tOxoAHBOKQmhXJxVnSZLmbij3mgMAAAAIt+KcFN13w1jdfuVJWrJ5r87741t6fQlzDQGIHkcsCplZwMwWdVQYRL+slAT1yU+lKAQAQCvoWwGdj5np4lHd9cKXTlNRdrI+8+As/fBfi1Xb0Og7GgAc1RGLQs65JknzzaxHB+VBJzCqOFvzNu6Rc853FAAAIgp9K6Dz6p2Xqqc+e4puOKWX7n9nnS7767vavb/OdywAOKK2DB/rKmmxmf3HzJ4/cAt3MESvUT2ytLOyTmV7GFMNAEAr6FsBnVRiXFA/uHCo7r52jJZv3acfv7DEdyQAOKK2LEn/w7CnQKcyqkeWJGnOhj0qzknxGwYAgMhD3wro5M4Z2kW3TOqrP/13lS4bXaRT++f5jgQArWrLkvTTJK2TFB+6P1PSnDDnQhQbWJiu5Pgg8woBANAK+lZAbPj8Gf3UKzdF33l2oWrqmV8IQGQ6alHIzD4j6UlJd4We6i7p2TBmQpSLCwY0oihTczeW+44CAEDEoW8FxIak+KB+eslwrd9VpT/9d6XvOADQqrbMKfR5SRMl7ZUk59xKSQXhDIXoN6pHtpZsruBbEQAAPuy4+1ZmNsXMlpvZKjO77TD7TDazeWa22MymtVtqAMdsYr88XTq6u+6atkYrtu3zHQcAPqQtRaFa59zBafPNLE4Sy0rhiEb1yFJ9o9PizXt9RwEAINIcV9/KzIKS7pB0rqQhkq42syGH7JMl6S+SLnTODZX08XbMDeA4fOe8wUpPitO3nl6opiZ+jQIQWdpSFJpmZt+WlGxmH5H0hKR/hTcWot2o4ixJ0twNe/wGAQAg8hxv32qcpFXOuTWhotKjki46ZJ9rJD3tnNsgSc657e2YG8BxyE1L1LfPG6zZ6/fo0ZkbfccBgA9oy+pjt0n6lKSFkm6W9JKke8MZCtGvICNJ3bOSmVcIAIAPO96+VXdJLX+jLJM0/pB9BkiKN7NSSemS/uCce/DQA5nZVElTJamwsFClpaUHt1VWVn7gMToW7e9XuNo/zzkNzA7ox/9aqOQ9q5Sd1Jbv5mMPf//9ov398/EZHLUo5JxrknRP6Aa02ageWaxABgDAIU6gb2WtHe6Qx3GSxkg6S1KypPfMbLpzbsUhGe6WdLcklZSUuMmTJx/cVlpaqpaP0bFof7/C2f69hu/XuX94U89uTtMDN46VWWs/0rGNv/9+0f7++fgMDluiNrPHQ38uNLMFh946LiKi1age2dpUXq1te2t8RwEAwLt26FuVSSpu8bhI0uZW9nnFObffObdT0puSRrZHfgAnpndeqm6bMkjTVuzQI+8zjAxAZDjSlUJfDv35sY4Igs5nVI8sSdLcDeWaMqyL3zAAAPh3on2rmZL6m1lvSZskXaXmOYRaek7Sn0OTVyeoeXjZ74/zfADa2XUTeum1Jdv0kxeX6NR+eeqRm+I7EoAYd9grhZxzW1rss805t945t17SdrV++TLwAUO7ZSghGNDcjUw2DQDAifatnHMNkr4g6VVJSyU97pxbbGa3mNktoX2WSnpF0gJJ70u61zm3qP3fDYDjEQiYfv3xkQqa6etPzGc1MgDetWWGsyckNbV43Bh6DjiixLighnbPYF4hAAA+6Lj7Vs65l5xzA5xzfZ1zPw09d6dz7s4W+/zaOTfEOTfMOXd7ewYHcOK6ZyXrexcM0fvrduu+d9b6jgMgxrWlKBQXWvZUkhS6nxC+SOhMRhVna0FZuRoam46+MwAAsYG+FRDjLh9TpLMHF+hXry7Xym37fMcBEMPaUhTaYWYXHnhgZhdJ2hm+SOhMRvXIUk19k5Zt5T87AABC6FsBMc7M9LNLhys1IagvPjJX5VV1R38RAIRBW4pCt0j6tpltMLONkr4p6ebwxkJncWCy6TkbmFcIAIAQ+lYAVJCepNuvGqU1O/br6ntmaPd+CkMAOt5Ri0LOudXOuZMlDZE0xDl3inNuVfijoTPonpWsouxkvbWSL0ABAJDoWwH4n0kD8nXP9SVas6NS19wzXTsra31HAhBjjrQk/UFmdr6koZKSzJoXx3DO/SiMudBJmJkmD8zXM3M2qa6hSQlxbbk4DQCAzo2+FYADJg3I1303jNWn/j5TV989XQ9/ZrwK0pN8xwIQI476G7qZ3SnpSklfVPNyqR+X1DPMudCJTBpQoP11jZq9niFkAADQtwJwqIn98nT/DeO0qbxaV909XVsranxHAhAj2nLZxinOuesk7XHO/VDSBEnF4Y2FzmRC31zFB02lK7b7jgIAQCSgbwXgQyb0zdXfbxqnbRU1mvKHN/XPGRvU1OR8xwLQybWlKFQd+rPKzLpJqpfUO3yR0NmkJcappGeOpi3f4TsKAACRgL4VgFaN7ZWjZz8/UQMK0/XtZxbqkr++qwVl5b5jAejE2lIUesHMsiT9WtIcSeskPRrGTOiEJg3M17Kt+7RtL5fCAgBiHn0rAIfVvzBdj009Wb+/cqQ27anWRXe8o+88s1B7a+p9RwPQCbVl9bEfO+fKnXNPqXm8+yDn3HfDHw2dyeSB+ZKkaSu4WggAENvoWwE4GjPTJaOK9N+vT9L1E3rpkfc36Pr73ldVXYPvaAA6mcOuPmZmlx5hm5xzT4cnEjqjgYXpKsxI1LTlO3RFCdMmAABiD30rAMcqIyleP7hwqE7uk6PPPTxHN/9jtu69vkSJcUHf0QB0Ekdakv6CI2xzkui4oM3MTJMG5OuVRVvV0NikuCBL0wMAYg59KwDHZcqwrvrFpSP0jacW6KuPzdcfrx6lYMB8xwLQCRy2KOScu7Ejg6DzmzSgQI/PKtP8snKN6ZnjOw4AAB2KvhWAE3HF2GLtranXT15cqozkOP3skuEyozAE4MQc6UohSZKZfbWVpyskzXbOzWv3ROi0Tu2Xp4BJ05bvoCgEAIhZ9K0AHK9Pn9ZHe6rqdMcbq5WZnKDbzh3kOxKAKNeWMTwlkm6R1D10myppsqR7zOwb4YuGziYzJV6je2SrlMmmAQCxjb4VgOP29XMG6hPje+jOaav1f0/MV3Vdo+9IAKJYW4pCuZJGO+e+5pz7mpo7MvmSTpd0QxizoROaNCBfC8oqtLOy1ncUAAB8oW8F4LiZmX500TB98cx+enJOmS66422t2r7PdywAUaotRaEekupaPK6X1NM5Vy2J3+xxTCaFlqZ/e+VOz0kAAPCGvhWAExIMmL52zkD9/cZx2lVZpwv+9I6eml3mOxaAKNSWotA/JU03s++b2fclvSPpETNLlbQkrOnQ6Qzrlqnc1ARNYwgZACB20bcC0C5OH5Cvl758mkYUZeprT8zXbU8tUFOT8x0LQBQ56kTTzrkfm9lLkk6VZJJucc7NCm3+RDjDofMJBEynD8jXmyt2qKnJKcBSmgCAGEPfCkB7KsxI0sOfHq9fv7Zcd01bo2HdM/XJk3v6jgUgShy1KCRJzrnZkmaHOQtixKQB+Xpm7ibN3ViuMT2zfccBAKDD0bcC0J7iggHdNmWQFmys0C9fWaZzhhSqICPJdywAUaAtw8eAdnXm4AKlJgT18PT1vqMAAAAAnYKZ6aeXDFNtQ5N+9AIjUQG0DUUhdLiMpHh9vKRY/1qwWdv31viOAwAAAHQKffLT9IUz+umFBVv0xvLtvuMAiAIUheDFjRN7qaHJ6R9cLQQAAAC0m5sn9VHf/FR999lFqq5r9B0HQISjKAQveuam6uzBhXp4xgbV1POfFQAAANAeEuOC+tklw1W2p1p/+M9K33EARDiKQvDmU6f21u79dXp27ibfUQAAAIBOY3yfXF1RUqR731qjZVv3+o4DIIJRFII343vnaEjXDN33zlo553zHAQAAADqNb507WBnJ8br10XnauLvKdxwAEYqiELwxM33q1N5asa1Sb6/a6TsOAAAA0Glkpybod1eM1KY91TrvD2/puXlcnQ/gwygKwauPjeyqvLRE/e3ttb6jAAAAAJ3K5IEFeunLp6l/YZq+/Og8fe3x+aqsbfAdC0AEoSgErxLjgrpuQk+VLt+hVdsrfccBAAAAOpXinBQ9fvMEfems/npmbpk+9se3tKCs3HcsABGCohC8u2Z8DyXEBXT/O1wtBAAAALS3uGBAX/3IAD06dYLqGpp02V/f1b1vrVFTE/N6ArGOohC8y0tL1CUndddTc8q0r6bedxwAAACgUxrXO0cvffk0nTmoQD95cak+9feZ2lVZ6zsWAI/CVhQys2Ize8PMlprZYjP7crjOhej38ZIi1dQ3qXT5Dt9RAAAAgE4rKyVBd35yjH500VC9s2qXzvvjW3pv9S7fsQB4Es4rhRokfc05N1jSyZI+b2ZDwng+RLFRPbKVl5ag15Zs8x0FAAAA6NTMTNdN6KVnPn+KUhPidM290/X0nDLfsQB4ELaikHNui3NuTuj+PklLJXUP1/kQ3YIB09mDC/XGsu2qbWj0HQcAAADo9IZ2y9S/vniqxvbK0feeW6zN5dW+IwHoYB0yp5CZ9ZI0StKMjjgfotM5QwtVWdug6Wt2+44CAAAAxITUxDj95vKRamxy+vYzC+Uck08DsSQu3CcwszRJT0m61Tm3t5XtUyVNlaTCwkKVlpZKkiorKw/eR8fz0f4NjU6JQemB1+fIbU7s0HNHIn4G/KL9/aL9/aL9ASC29MhN0TenDNQP/rVET83ZpMvHFPmOBKCDhLUoZGbxai4IPeyce7q1fZxzd0u6W5JKSkrc5MmTJUmlpaU6cB8dz1f7n7V1tmat26PTT5+kQMA6/PyRhJ8Bv2h/v2h/v2h/AIg9103opZcWbtWP/rVYp/XPU2FGku9IADpAOFcfM0l/k7TUOfe7cJ0Hncs5Q7po+75azSsr9x0FAAAAiBmBgOmXl49QbUOTvvPMIoaRATEinHMKTZR0raQzzWxe6HZeGM+HTuCMgQWKC5heW8wqZAAAAEBH6p2Xqq+fM1D/XrpNz8/f7DsOgA4QztXH3nbOmXNuhHPupNDtpXCdD51DZkq8JvTN1WtLtvqOAgAAAMScm07trVE9svT951mNDIgFHbL6GHAszhlSqDU79mvV9krfUQAAAICYEgyYfn35SDU0Ol3+13e1avs+35EAhBFFIUScs4cUShJXCwEAAAAe9CtI06NTT1Zdo9Pld76nuRv2+I4EIEwoCiHidM1M1siiTOYVAgAAADwZ1j1TT312gjKS4nXNPTNUuny770gAwoCiECLSOUO7aN7Gcm3bW+M7CgAAABCTeuam6qnPnqLeean69N9n6Zm5Zb4jAWhnFIUQkc4JDSF7fQlXCwEAAAC+5Kcn6rGbT9bYXjn66uPzNWPNLt+RALQjikKISP0K0tQ7L1WvLmZeIQAAAMCn9KR4/e2GEhVnp+gbTy1QdV2j70gA2glFIUQkM9N5w7vonVU7tbWCIWQAAACATykJcfrlZSO0fleVfvPact9xALQTikKIWFeUFKvJSY/P2ug7CgAAABDzJvTN1bUn99R976zVrHW7fccB0A4oCiFi9cxN1an98vTYzI1qbHK+4wAA4J2ZTTGz5Wa2ysxuO8J+Y82s0cwu78h8ADq/284dpO5ZyfrGkwtUU88wMiDaURRCRLtqXLE2lVfrrZU7fEcBAMArMwtKukPSuZKGSLrazIYcZr9fSnq1YxMCiAWpic3DyNbs3K/fvb7CdxwAJ4iiECLaOUO6KDc1QY++zxAyAEDMGydplXNujXOuTtKjki5qZb8vSnpK0vaODAcgdkzsl6drxvfQvW+t0ZwNe3zHAbyoqKrXv5ds04pt+1Tf2OQ7znGL8x0AOJKEuIAuG1Ok+95eq+37alSQnuQ7EgAAvnSX1PJbkjJJ41vuYGbdJV0i6UxJYw93IDObKmmqJBUWFqq0tPTgtsrKyg88Rsei/f2i/dvutHSnVxNNN9//nm4bl6Tc5BO/3oD294v2b7uluxp194Ja7altnuYkaFKXVFP3tID6ZgU1vmtQWYnH/jPh4zOgKISId+XYYt395ho9ObtMn5vcz3ccAAB8sVaeO3TSvdslfdM512jW2u6hFzl3t6S7JamkpMRNnjz54LbS0lK1fIyORfv7Rfsfm8IBe3T9397X7+ZLD396rHrlpZ7Q8Wh/v2j/o6tvbNLvXl+hO2etVu/cVP3u6iGqqK7X8m37tHLbPi3buk/vL6vW4ytMkwbk67LRRTprcIGS4oNtOr6Pz4CiECJe3/w0je+do8dmbtQtp/dVIHD4Ti4AAJ1YmaTiFo+LJG0+ZJ8SSY+GCkJ5ks4zswbn3LMdkhBATBndI1uPTD1Z1933vj5+13t66FPjNbBLuu9YQFis27lfX350ruaXVeiqscX63gVDlJLw4ZLKqu379NScTXp6Tpn+u2y7MpPjNbhruuKDAcUFTHHBgBLjAvro0C46f3hX77/fUhRCVLh6XA/d+tg8vbdmlyb2y/MdBwAAH2ZK6m9mvSVtknSVpGta7uCc633gvpk9IOkFCkIAwmlY90w9fvPJ+sS9M3Tl3e/p7zeO08jiLN+xgGO2s7JWs9bt1vtr92juxj3aV9OghsYm1Tc61Tc2qbyqXskJQf31E6N17vCuhz1Ov4J0fXPKIH39nIF6Z9VOPTt3k8r2VKuyoUENLY71woItuuvN1frmlEE6rX9+B77TD6IohKgwZVgXZT4fr0fe30BRCAAQk5xzDWb2BTWvKhaUdJ9zbrGZ3RLafqfXgABiVr+CdD15yym65t7puuae6br7uhL67IgK5VV1+mvpar2+dJvW7NgvSUqMC2hkcZYGFqYrLmiKCwSUEGdKS4zTjRN7q1tWcpuOHQyYTh+Qr9MHfLjg09jk9Ny8Tfrtayt07d/e18R+ufrmlEHt+t7aiqIQokJSfFCXju6uh6av167KWuWmJfqOBABAh3POvSTppUOea7UY5Jy7oSMyAYAkFeek6ImbT9G1f5uhT/5thqae3kdf/cgAJca1bS4VoCPVNzbp4enr9ft/r9S+mnpNGpCvj48p1rje2RrWPTPsf2+DAdOlo4t0/oiuenj6Bv35jVW68M/v6EujEjU5rGf+MIpCiBpXj+uh+99Zp6fmlGnq6X19xwEAAADQQpfMJD37+Yn6yYtLdde0NZq2fIduv+okDeqS4TsacNAby7frJy8s0eod+zWxX66++7Eh3v6OJsYFddOpvfXxkiI9NH2D+jZu6PAMFIUQNQYUpmt490z9e8l2ikIAAABABEpNjNPPLx2uswcX6JtPLdCFf3pHX//oAI3pma21O6u0bud+rd21X7sr6zR1Uh+dMbDAd2R0Qvtq6vXn/67SCwu2qKGpSY1NUpNzamhs0t6aBvXOS9W915XorMEFOtJqnR0lPSlen53cV6WlGzv83BSFEFXG9c7RQ9PXq76xSfHBgO84AAAAAFpx1uBCvXrr6frW0wv1s5eWHXw+GDAVZSerscnpxvtn6ktn9tOXzx6gICsMox045/TsvE362UvLtGNfrT4ypFC5qQkKBExBMwVM6leQpivH9lBCHL9PShSFEGXG9MzW395eqyWb97KqAQAAABDBctMSdde1Y/TWyp1qaGpSr9xUFWWnKCEuoJr6Rn332UX6439Xae7Gct1+5Um+4yLKLd5coR88v1gz1+3RyKJM3XNdiU7id8ajoiiEqDKmZ7Ykafb6PRSFAAAAgAhnZq2uvpQUH9SvPz5SJb2y9d3nFutjf3pbnxqkDp9kF9Fv+74a/f71FXps5kZlpSTol5cN18fHFCvA1WdtQlEIUaUwI0nds5I1e8Me3aTevuMAAAAAOAFXju2hod0y9dmHZ+unM6o1s3KWbpzYW+N750TEXC+IXNV1jbr3rTX667TVqmto0vWn9NKtZw1QZkq872hRhaIQos6YntmauW637xgAAAAA2sGw7pl64Qun6dv/eEPvrN2tVxdv05CuGbpxYi9dMLKbkuJZ1h7/U15Vp1cXb9Xt/16pLRU1+ujQQt127mD1zkv1HS0qURRC1BnTM1vPz9+szeXV6paV7DsOAAAAgBOUmRKvjw9M0G9uPE3PzN2k+99Zq/97coF+/epyffUjA/TxkuI2T0ZdU9+oytoG5aUlhjk1OkJDY5Pml5Vr2oqdenPFDi0oK1eTk0YUZer2K0/S+D65viNGNYpCiDot5xWiKAQAAAB0HskJQV0zvoeuHlest1ft1O9eX6Hbnl6o+95Zq2+dO1iTB+YfHFZWUVWv99bs0vQ1u7R+135t3VurrRXV2lNVL0m6sqRYP7p4qBLjuNIoGqzeUan73l6reRvLtb+2QZW1jdpf26Dq+kZJUsCkEUVZ+sKZ/TVpQJ5GFWczb1A7oCiEqDOoS7qS44OavX6PLhjZzXccAAAAAO3MzHRa/3yd2i9PLy/aql++skw3PjBTp/TN1fCiTL23epcWbapQk5OS44Pqk5+qbplJGt0jS10zk7Szsk4PvLtOq3dU6s5rx3DVUIRyzmnG2t265801+s+y7UqIC2hCn1z1yU9TWmJQqQlxSk2MU//CNJ3aL09ZKQm+I3c6FIUQdeKCAZ1UnKU5G/b4jgIAAAAgjMxM5w3vqrMHF+rhGev1x/+s1Mx1uzWqOFtfOqu/Tumbp5OKs5QQF/jQa8f0zNb/PTlfF/7pbd1zfYmGdsv08A5ii3NOb6/aqfveXqtGJ2UlxysrJV5ZyfFKS4pTXUOTauqbVF3fqJr6Ri0oq9DCTRXKSU3Ql8/qr2sn9KSA18EoCiEqjemZrb9OW62qugalJPDXGAAAAOjMEuICunFib10zvoeampqHmR3NBSO7qVduqqb+Y5Yu++u7+vXlI/WxEV1Z1SxM5mzYo1+9skzT1+xWl4wkFWYmacOu/SqvrldFdb2ca94vYM1XdyUnBFWQnqSfXTJcl47uzoTinvDbNKLSmJ7ZamxyWlBWoZOZWAwAAACICcc6P9Dwokw994WJuuUfs/XFR+bqzmmr9YnxPXXRSd2Umsivwyeqqclp4aYK/em/q/TvpduUl5ag718wRNeM7/GBz6qpyWl/XYMS44KKDxqFuQjCTwGi0qgeWZKaJ5umKAQAAADgcArSk/TI1JP1+KwyPTx9vb79zEL9/KWlumR0d103oaf6FaT7jhg1nHNavWO/3lu9U++t2aX3Vu/Snqp6pSfF6evnDNCNE3u3WmwLBEzpSfEeEuNoKAohKmWlJKhvfqrmrGdeIQAAAABHlhgX1LUn99Qnx/fQnA179ND0DXp05kY9NH29bjilt756zgCldbIrh5xzKttTrUWbKlSQkaiTirMVPM7VurZUVOvpOZv0xKyNWrerSpLULTNJZw0u1Cl9c3XWoEJlplD0iUad6289YsqYntl6bck2Oee4/BAAAADAUZmZxvTM0ZieOfrux4bod68v1/3vrtWLCzfrex8bqvOGd4nY3y2O9ntPTX2j5mzYoznr92jexnLN21iunZV1B7fnpSXozEEFOntwoU7tn3fEuVmdc9q1v04z1uzW47M26q2VO9TkpPG9c/SZ0/vo1H556pGTErFthbajKISoNaZnth6fVaY1O/erb36a7zgAAAAAokhOaoJ+cvFwXT6mWN95ZqE+/885On1Avr593iAN6pLhO95BC8rK9Zc3Vus/y7apODtFg7qma1CXDA3qkq6UhDi9v263pq/ZpXkbylXX2CRJ6pufqkkDCnRSjywN756pDbur9O8l2/Tyoq16fFaZEoIBdc1KUk5qgnJTE5WbmqDdO2r1yMZZWr+rSht3V2l/XaOk5iuCPn9GP10+pkg9c1N9NgXCgKIQotaYntmSmucVoigEAAAA4HicVJyl5z4/Uf+Yvl6/fW2Fptz+lvrkp+qcIV300aGFGlmUpcBxDrs6Xs45zVi7W3e8sUpvrdyp9KQ4XTm2WDv31WnJ5r16edHWD6zmNbx7pm6Y2Esn98nRmB45HxrKdVJxli4c2U31jU2auXa3pq3coS3lNdq9v06byqu1oKxcFVUNKsqpVM/cVJ3cJ1c9c1M0sEu6xvfOPe5hZ4h8FIUQtfrkpSkzOV5z1u/RFSXFvuMAAAAAiFJxweYl7y8Y2U0vL9yi15Zs071vrdGd01arMCNRZwws0OkD8jWxX54yk9tv7pyGxib9e+k2rdm5XxXV9aqoal6+ff2uKi3Zsld5aYm67dxB+sT4Hh+YqHl/bYNWbNunfTUNGtUjq82TOMcHAzqlX55O6Zf3oW2lpaWaPHlye701RAmKQohagYBpdI8szWayaQAAAADtIC8tUddO6KVrJ/RSRVW93li+Xa8t2aoXF2zRozM3KmDSqB7ZOr1/vk7tn6eRRZmKCwaO+Tw19Y16YtZG3f3WGm3cXS1JSogLKCs5Xlkp8cpOSdCPLxqqj5cUKyk++KHXpybGaVSP7BN+vwBFIUS1MT2z9cbyHaqoqme2ewAAAADtJjMlXheP6q6LR3VXQ2OT5m0s17QVO/Tmih26/T8r9Pt/r1B6Upwm9MnVqf3zdErfXPXOSzvsUCvnnLbvq9WTs8t039trtWt/nUb1yNL3PjZUp/bLU3LCh4s/QLhRFEJUGx2aV2jOxj06Y2CB5zQAAAAAOqO4YEAlvXJU0itHXztnoHbvr9O7q3fqnVU79dbKnXptyTZJzVf79MlLVd+CNPXLT1N6UpxW79ivldv2aeX2SlVU10uSJg/M12cn9dW43jms4AWvKAohqp1UnKX4oGna8h0UhQAAAAB0iJzUBH1sRDd9bEQ3Oee0YXeV3l+7W6u2V2rV9kot2lShlxZukXNSVkq8BhSk62Mjuqp/QZpO7psbUaubIbZRFEJUS0mI0zlDu+jZeZv0rfMGKTGOSy4BAAAAdBwzU8/c1A8t115T36j9tQ3KSU3gaiBErGOfEQuIMFeNLVZ5Vb1eXbzNdxQAAAAAkCQlxQeVm5ZIQQgRjaIQot7EvnnqnpWsx2Zu8B0FAAAAAICoQVEIUS8QMF05tljvrNqlDbuqfMcBAAAAACAqUBRCp/DxkiIFTHp81kbfUQAAAAAAiAoUhdApdM1M1uSBBXpi9kY1NDb5jgMAAAAAQMSjKIRO48qxxdq2t1bTVuzwHQUAAAAAgIhHUQidxpmDCpSXlqhHZzKEDAAAAACAo6EohE4jPhjQ5WOK9N9l27V9b43vOAAAAAAARDSKQuhUrhxbrMYmpydml/mOAgAAAABARKMohE6ld16qxvfO0eOzNqqpyfmOAwAAAABAxKIohE7n6nE9tH5XlWau2+07CgAAAAAAEYuiEDqdswYXKC5gemM5q5ABAAAAAHA4FIXQ6aQnxWt0z2y9ydL0AAAAAAAcFkUhdEqTBuRryZa92rGv1ncUAAAAAAAiEkUhdEqTBuRLkt5aydVCAAAAAAC0hqIQOqUhXTOUm5qgaQwhAwAAAACgVRSF0CkFAqbT+ufprZU7WZoeAAAAAIBWUBRCp3X6gHzt3l+nxZv3+o4CAAAAAEDEoSiETuu0/s3zCr3JvEIAAAAAAHxI2IpCZnafmW03s0XhOgdwJPnpiRrSNYN5hQAAAAAAaEU4rxR6QNKUMB4fOKpJA/M1Z/0e7aup9x0FAAAAAICIEraikHPuTUm7w3V8oC1O75+vhian91bv8h0FAAAAAICIwpxC6NTG9MxWakKQeYUAAAAAADhEnO8AZjZV0lRJKiwsVGlpqSSpsrLy4H10vM7U/v0zpVfnb9RZmTtlZr7jtFln+gyiEe3vF+3vF+0fucxsiqQ/SApKutc594tDtn9C0jdDDyslfdY5N79jUwIAgGjhvSjknLtb0t2SVFJS4iZPnixJKi0t1YH76Hidqf03JK7T955brF7Dx6l3XqrvOG3WmT6DaET7+0X7+0X7RyYzC0q6Q9JHJJVJmmlmzzvnlrTYba2kSc65PWZ2rpr7WOM7Pi0AAIgGDB9Dp3f6gaXpWYUMABDdxkla5Zxb45yrk/SopIta7uCce9c5tyf0cLqkog7OCAAAokg4l6R/RNJ7kgaaWZmZfSpc5wKOpFdeqnrmplAUAgBEu+6SNrZ4XBZ67nA+JenlsCYCAABRLWzDx5xzV4fr2MCxOr1/vp6aU6aa+kYlxQd9xwEA4Hi0NjGea3VHszPUXBQ69TDbW53TUWJOKd9of79of79of79of/98fAbe5xQCOsK5w7voH9PX69m5m3TVuB6+4wAAcDzKJBW3eFwkafOhO5nZCEn3SjrXObertQMdbk5HiTmlfKP9/aL9/aL9/aL9/fPxGTCnEGLChD65GtotQ/e+vVZNTa1+qQoAQKSbKam/mfU2swRJV0l6vuUOZtZD0tOSrnXOrfCQEQAARBGKQogJZqapp/fRqu2VKl2x3XccAACOmXOuQdIXJL0qaamkx51zi83sFjO7JbTb9yTlSvqLmc0zs1me4gIAgCjA8DHEjPOGd9UvXl6mu99cozMHFfqOAwDAMXPOvSTppUOeu7PF/U9L+nRH5wIAANGJK4UQM+KDAd00sbemr9mtBWXlvuMAAAAAAOAVRSHElKvGFSs9MU73vLXWdxQAAAAAALyiKISYkp4Ur6vH99BLC7eobE+V7zgAAAAAAHhDUQgx54ZTeskk3f/OOt9RAAAAAADwhqIQYk63rGRdMLKbHn1/gyqq633HAQAAAADAC4pCiEmfPq239tc16pH3N/iOAgAAAACAFxSFEJOGdsvUqf3ydO9ba1RRxdVCAAAAAIDYQ1EIMeu2cwdpT1W9fv7yUt9RAAAAAADocBSFELOGdc/Up0/rrUdnbtS7q3f6jgMAAAAAQIeiKISYdutZA9QzN0XffnqhauobfccBAAAAAKDDUBRCTEtOCOrnlwzXul1Vuv3fK33HAQAAAACgw1AUQsw7pV+erigp0j1vrdGiTRW+4wAAAAAA0CEoCgGSvnPeEGWnJOi2pxeoobHJdxwAAAAAAMKOohAgKTMlXj+6aKgWbdqru95c4zsOAAAAAABhR1EICDl3WBedP6Krfv3qcj03b5PvOAAAAAAAhFWc7wBApDAz/fbjI7VjX62+9vh8ZaUkaNKAfN+xAAAAAAAIC64UAlpIig/q3utL1L8wXbf8Y7bmbtjjOxIAAAAAAGFBUQg4REZSvP5+01gVZCTqxgdmauW2fb4jAQAAAADQ7igKAa0oSE/SP24ar/hgQNfd97427KryHQkAAAAAgHZFUQg4jB65Kfr7jeO0v7ZB5//pLSafBgAAAAB0KhSFgCMY0i1DL3zxNPUvSNOXH52nWx+dq7019b5jAQAAAABwwigKAUfRIzdFj988Qbee3V//WrBF597+lmau2+07FgAAAAAAJ4SiENAGccGAbj17gB6/eYKCAdOVd72ne95cI+ec72gAAAAAABwXikLAMRjTM1svffk0fXRoF/30paW67amFqmto8h0LAAAAAIBjRlEIOEZpiXG645rR+sIZ/fTYrI269m8ztGd/ne9YAAAAAAAcE4pCwHEIBExf/+hA/f7KkZq7oVwX/+Udrdpe6TsWAAAAAABtRlEIOAGXjCrSI1NP1v7aBl18xzv6039WqrK2wXcsAAAAAACOiqIQcILG9MzWs5+fqAl9c/Xb11do0q/e0N/eXqua+kbf0QAAAAAAOCyKQkA7KMpO0T3XleiZz52iwV0z9OMXluiM35TqnzM2qL6RiagBAAAAAJGHohDQjkb1yNZDnx6vf35mvLpmJunbzyzUWb+dpqfnlKmxieXrAQAAAACRg6IQEAan9M3TU589RffdUKK0xDh99fH5+ujtb+rFBVvURHEIAAAAABAB4nwHADorM9OZgwo1eUCBXl28Vb97fYU+/8856pOfqitKinXp6O4qSE/yHRMAAAAAEKMoCgFhFgiYzh3eVecM7aIXFmzWQ9PX6xcvL9OvX12uMwcV6MqSYk0emK+4IBfuAQAAAAA6DkUhoIMEA6aLTuqui07qrlXbK/XErI16ak6ZXl+yTTmpCTpveBddOLK7SnpmKxCwYz7+9r01em3JNu2raVBxTrJ65KSoODtFWSnxMjv24wEAAAAAOjeKQoAH/QrS9K3zBuvrHx2oN5Zt1/PzN+vJ2WV6aPoGdctM0rnDu6p2V712zS5TWlKc0hPjlHrwFlRKQpxSE4LaUlGjVxdv1cuLtmrOhj1yrUxXlJ4Yp/F9cnXxqG46e3ChkuKDHf+GAQAAAAARh6IQ4FF8MKBzhnbROUO7aH9tg/69dJuen7dZD763TvWNTg8tnd+m4wzumqGvnD1AU4Z1UbesZG3cXaUNu6u0cXeV1u7cr38v3aZ/L92mtMQ4fXRoF108qpsm9MllyBoAAAAAxDCKQkCESE2MOzi8rK6hSa/+d5pGjhmvfbX1qqxpUGVtg/bXNWp/bUPo1qjUxKA+MqRQPXNTP3CswV0zNLhrxsHHP7pomGas2aVn5m7SK4u26qk5ZcpJTdA5Qwo1ZVgXndI3TwlxFIgAAAAAIJZQFAIiUEJcQOkJph65Ke1yvGDAdEq/PJ3SL08/vniYSpdv18uLtuqFBVv06MyNykiK0+SBBeqbn6bu2ckqCt1yUhNU3+BU29iouoYm1TU0KS89URlJ8e2SCwAAAADgD0UhIMYkxQc1ZVhXTRnWVTX1jXpn1U69tHCr3lm1U8/P33zU1wdMGlGUpVP75enU/nka3SObq4wAAAAAIApRFAJiWFJ8UGcNLtRZgwslSTX1jdpSUaOyPVXatKdau6vqlBAMKDEuoITQbe2O/Xp71U79ddpq/fmNVUqODyonNUFNzqmxyanJNReOTumbq0tGF2liX+YuAgAAAIBIRFEIwEFJ8UH1zktV77zUI+731XMGam9Nvaav3qV3V+/SvpoGBax5mJqZqbquQf9dtl3PztusvLREXTiym84f0VX9CtKUkRQnM+ugdwQAAAAAOByKQgCOS0ZS/MGV01pT29CoN5bt0LNzN+mh6et13ztrJUlpiXHqlpWkblnNcxaZTE7u4Ot65abq0tHdVZTdPvMpAQAAAABaR1EIQFgkxgU1ZVgXTRnWReVVdXp39S5t2lOtzRXV2lxerc3lNVq5rfLg/maSc9Izczfp9/9eoVP75enjJcU6Z0ihkuKDHt8JEPkqquvV1OQUFzTFBwOKC9jBK/cAAACAw6EoBCDsslISdN7wrm3at2xPlZ6cXaYnZpXpS4/MVWZyvE7rn6cRRZka3j1Lw7pnKJ3VzxDj9uyv0/Q1zcM33129U6t37P/QPvFBU3F2inrlpapXbqp656UoLy1RdY1Nqq1vUm1Do2obmpSRHK8hXTPUryCNAiwAAECMoSgEIKIUZafo1rMH6Etn9te7q3fpydkbNXPdHr2wYMvBffrkp+rswYW6cGQ3De2WwdUQiHjOuVb/njY2OS3cVKG3V+7QWyt3as3O/apvbFJDo2v+s8nJJCXGBZQYH1RCMKBgwLS5olrOSSkJQY3rnaPLxhQpJT6ohianutDr99c2aMPuKq3duV/vrd6l6vrGI2YMBkx98lI1uGuGegYaNDk8TQEAAIAIQlEIQEQKBEyn9m9e9l6Sdu+v08JNFVpYVq5Z6/fo/nfW6u4316hPfqouGtld5w3voh65KUqM40oH+FFRVa+Z63Zr5vrd2lxeo537arWzsla79tepvKpOaYlxyk1LVE5qgnJSE+Sc9P7aXdpb0yBJGtI1Q2cNKlBCXEBxgYDi40zxgYCanFNtQ5PqGpqv7qlraFKf/GKd0jdXI4uzFN+G1f2cc9q2t1Z7quoOFpgOrCq4q7JOS7fsDd32afb6PQrmNYW7uQAAABABKAoBiAo5qQmaNCBfkwbkS5LKq+r08qKtem7eJt3+nxX6/b9XHNyvID1RhRlJKkhPVG5aovLSEpSXlqjctARJ0va9tdq+r1bb9tZoR2WtspLjNahLugZ1zdCAwnRlJjM8rbNwrnkS82O9mmxXZa3K9lSr0Tk55+Sc1OSkhqYm1dQ3qqa+SdV1jaqub9TKbfs0Y+1uLd+2T85JCcGAumUlKS8tUX3z0zSud4KyUuJVWdOgXfvrtHt/nTburlJdQ5OmDOuiU/vna2LfXOWmJYajCSQ1v/8umUnqkpn0oW0ZSfHqnZf6gSGe/33jjbBlAQAAQOSgKAQgKmWlJOjqcT109bge2lpRozdX7NDWvTXatrdG2/bWavu+Gi3fuk+79teqvtG1eoz0xDjlpydqZ2WtHp7RcPD5bplJSrE6/XPDLOWlJyovLVEF6Ynqnp2s4uxkdc9KUXLCB69IqqlvVEV1vfbXNrS4qqP5z6LsZPXMTWGYWwdxzmnuxnI9N3eTXliwRfWNTRpRlKXhRZka0T1Tw7pnKhAwlVfVqbyqXuVV9dq1v1artldqxbZ9WrmtUrv217X5fCkJQY3pma3zh3fVuN45GlmcFfVz8wT4uwoAABATKAoBiHpdMpN0xdjiVrc557S3pkE7K2u1c1+tJDVfRZSRqJSEuIP7bKloLiIt27pPK7bt07L1W7Ru137NWr9He6rq5A6pK+WlJSgrJUF7q+tVUV2v2oYjD7fpmpmkCX1yNaFvrk7uk6ui7OSYKRLVNTRpw+4qrdlRqfpGpz75qeqdl3pChZPqukZtqahWVV2jauqbr9iprmvUwk0Vem7eZm3YXaXEuIDOHlyozJR4LSgr1z1vrlFDU+sFQklKS4xT/8I0nT24UP0L09QzN1XxweYVvAImmZpX9EpOCCo5Pqik+ICS4oPKSU1o0xAuoD2Y2RRJf5AUlHSvc+4Xh2y30PbzJFVJusE5N6fDgwIAgKhAUQhAp2ZmykyOV2ZyvPrmpx12n25ZyeqWlawzBhVIkkpLyzV58iRJUkNjk3ZW1mlTeZXK9lSHblWqqK5XRlLzsTNC50hLjAvN2RJQYlxQcQHTiu2Vmr56l6at2KGn526SJCXHB9U9O1nds5JVlJ2souwU9c1PVf/CdBVnJysugooMzjlt3F2t+WXlWlBWrqVb9ikl4X/5u2clKz89UeVV9QeH5W3fV6stFdVau3O/Nu6u0qG1GDOpKDtZ/fLT1CUzSRlJzW2YkRSn9KR4LdncoO2zNqq+sUn1DU2qqm/UxtCkyet2Vmnr3ppWswZMOqVvnr54Zj9NGdblAyvV1dQ3avnWfVq8ea8C1ny1WVZKvLJTEpSdGq/8tMSYKdQhOplZUNIdkj4iqUzSTDN73jm3pMVu50rqH7qNl/TX0J8AAAAfQlEIAI4iLhg4OB/LmJ7H/vrxfXJ17ck91dTktHJ7pd5fu0vrdlWpbE+VNpU3F1vKq+oP7p8QDKhPfqp65qY0F5xaFEwOFJ9a3lIS45QUFzjuQtKBq262VNRoa0XzPEvb99aG/qzRim37tCeULyEY0MAu6dq2t0Zvr9qpqrrWV7TKTU1Ql8wkDe+eqYtGdlPv/FT1zktTQjCgNTsrtXr7fq3aUanV2yu1aPNe7W3taqsFCz7wMCc1Qb1yU3RKv1z1zk1VUU6yUhLilBwfPHj1TpfM5rl8WpMUH9TI4iyNLM46rnYCIsA4Saucc2skycwelXSRpJZFoYskPeiaJ9SabmZZZtbVObflw4cDAACxjqIQAHSQQMA0sEu6BnZJ/9C2vTX1Wr29Uiu3Vx78c82O/dpbU6+91Q1HXU5ckuKDpqS4oBLjg0pOCCgpLqik+OZiSWJ88ypWDY1OTc6pscmpqq5RW/fWfKAgdUBqQlD56YnKT0/UOUO6aERxpkYWZWlAYboS4pqLT845VVTXq2xPtXZW1io7JUEFGc1zMB1pONWQbhmtPl/b0Kh9NQ3aW12v999/X6eecrISggHFB5uvvDow3A+IYd0lbWzxuEwfvgqotX26SzpsUWjXrl164IEHDj4uLy/XunXrTjAqjhft7xft7xft7xft75+Pz4AeNgBEgIykeI3qka1RPbJb3V7f2KR9NQ2qCM1hVFFdf3A+o6q6BtXUt1gVq75RtfWNqmlonmenpr5JlbUNCpopEDDFBwNKijflpCZqbK8cdclMUresJHXJSFaXzOZV21ITj/7fg5mFhmAltEsbJMYFlZgWVF5aojakBlSUndIuxwU6kdbGNx46UVZb9pGZTZU0VZK6du2q8vLyg9saGxs/8Bgdi/b3i/b3i/b3i/b3z8dnQFEIAKJAfDCgnNQE5aS2TwEGQFQqk9RyVv0iSZuPYx855+6WdLcklZSUuFtvvfXgttLSUk2ePLldAuPY0f5+0f5+0f5+0f7+hfMz+MpXvtLq85EzkykAAACOZKak/mbW28wSJF0l6flD9nle0nXW7GRJFcwnBAAADocrhQAAAKKAc67BzL4g6VU1L0l/n3NusZndEtp+p6SX1Lwc/So1L0l/o6+8AAAg8oW1KGRmUyT9Qc0dl3udc78I5/kAAAA6M+fcS2ou/LR87s4W952kz3d0LgAAEJ3CNnzMzIKS7pB0rqQhkq42syHhOh8AAAAAAADaLpxzCo2TtMo5t8Y5VyfpUUkXhfF8AAAAAAAAaKNwDh/rLmlji8dlksYf6QW7du3SAw88IEkqLy/XunXrwpUNR0H7+8dn4Bft7xft7xftDwAAEBvCWRSyVp5zH9rJbKqkqZLUtWtXlZeXS5IaGxsP3kfHo/394zPwi/b3i/b3i/YHAACIDeEsCpVJKm7xuEjS5kN3cs7dLeluSSopKXG33nqrJKm0tFSTJ08OYzwcCe3vH5+BX7S/X7S/X+Fs/6985SthOS4AAACOXTjnFJopqb+Z9TazBElXSXo+jOcDAAAAAABAG4XtSiHnXIOZfUHSq2pekv4+59zicJ0PAAAAAAAAbRfO4WNyzr0k6aVwngMAAAAAAADHLpzDxwAAAAAAABChKAoBAAAAAADEIIpCAAAAAAAAMYiiEAAAAAAAQAyiKAQAAAAAABCDKAoBAAAAAADEIIpCAAAAAAAAMcicc74zHGRmOyStDz3Mk7TTY5xYR/v7x2fgF+3vF+3vVzjbv6dzLj9Mx8ZxOKT/JfHz5xvt7xft7xft7xft71+H98EiqijUkpnNcs6V+M4Rq2h///gM/KL9/aL9/aL9Yxufv1+0v1+0v1+0v1+0v38+PgOGjwEAAAAAAMQgikIAAAAAAAAxKJKLQnf7DhDjaH//+Az8ov39ov39ov1jG5+/X7S/X7S/X7S/X7S/fx3+GUTsnEIAAAAAAAAIn0i+UggAAAAAAABh0mFFITMrNrM3zGypmS02sy+Hns8xs9fNbGXoz+wWr/mWma0ys+Vm9tEWz48xs4WhbX80M+uo9xGtjrX9zewjZjY71M6zzezMFsei/Y/D8fwMhLb3MLNKM/t6i+f4DI7Rcf4bNMLM3gvtv9DMkkLP0/7H6Dj+DYo3s7+H2nmpmX2rxbFo/2N0hPb/eOhxk5mVHPIa/g/uJOiD+UUfzC/6X37R//KL/pd/UdEHc851yE1SV0mjQ/fTJa2QNETSryTdFnr+Nkm/DN0fImm+pERJvSWtlhQMbXtf0gRJJullSed21PuI1ttxtP8oSd1C94dJ2tTiWLR/B3wGLV73lKQnJH2dz6Dj2l9SnKQFkkaGHufyb1CHtv81kh4N3U+RtE5SL9q/3dt/sKSBkkollbTYn/+DO9HtOH7++Pz9tj99MI/t3+J19L88tL/of/luf/pfHfcZREwfrMOuFHLObXHOzQnd3ydpqaTuki6S9PfQbn+XdHHo/kVq/gtZ65xbK2mVpHFm1lVShnPuPdfcMg+2eA0O41jb3zk31zm3OfT8YklJZpZI+x+/4/gZkJldLGmNmj+DA8/xGRyH42j/cyQtcM7ND71ml3OukfY/PsfR/k5SqpnFSUqWVCdpL+1/fA7X/s65pc655a28hP+DOxH6YH7RB/OL/pdf9L/8ov/lXzT0wbzMKWRmvdT8LcgMSYXOuS1Sc4NJKgjt1l3SxhYvKws91z10/9Dn0UZtbP+WLpM01zlXK9q/XbTlMzCzVEnflPTDQ17OZ3CC2vgzMECSM7NXzWyOmX0j9Dztf4La2P5PStovaYukDZJ+45zbLdr/hB3S/ofD/8GdFH0wv+iD+UX/yy/6X37R//IvUvtgce1xkGNhZmlqvhzzVufc3iMMg2ttgzvC82iDY2j/A/sPlfRLNVftJdr/hB3DZ/BDSb93zlUesg+fwQk4hvaPk3SqpLGSqiT9x8xmS9rbyr60fxsdQ/uPk9QoqZukbElvmdm/xd//E3Jo+x9p11ae4//gKEcfzC/6YH7R//KL/pdf9L/8i+Q+WIdeKWRm8WpuiIedc0+Hnt4WuhTqwGWZ20PPl0kqbvHyIkmbQ88XtfI8juIY219mViTpGUnXOedWh56m/U/AMX4G4yX9yszWSbpV0rfN7AviM/j/7d27ix11GMbx76MWYhYUhSiIEIuAWoiaqBvwhoqIXQohSHAlhVjFKoVoERUVLMQijWD8D8QLKFkheMHgDTUsm2iIhdhFDAqG4IXwWswIx8AKZ9id2T3z/cCwZ+dy+J134MzDe+bSWYfvoI+r6peqOgu8D9yC9e9syvo/Ahyqqr+r6mfgCLAd69/ZCvVficfgGWMGG5YZbFjmr2GZv4Zl/hrees9gfT59LMBB4LuqemVi0bvAQvt6AXhnYv6u9hrqa4GtwJft6W2/J5lv3/PRiW20gmnrn+Qy4D3gqao68u/K1r+7afdBVd1ZVVuqagvwKvBiVR1wH3TT4TtoEbgxySXtddV3A8etfzcd6v8TcG8am4B54Hvr383/1H8lHoNniBlsWGawYZm/hmX+Gpb5a3gbIoNVf3fdvoPm9KYl4Gg7PURzR/nDwMn27+UT2zxNc7ftE0zcWZumW7ncLjsApK/PsVGnaesPPENzPenRiWmz9e9vH5y37X7++/QL90EP9Qd209xkchl42fr3V39gjuapL8eA48A+678m9d9J88vTn8ApYHFiG4/BMzJ1/P5z/w9Uf8xgg9b/vG33Y/7qvf6YvwarP+avPvfBuslgad9ckiRJkiRJIzLI08ckSZIkSZI0LJtCkiRJkiRJI2RTSJIkSZIkaYRsCkmSJEmSJI2QTSFJkiRJkqQRsikkSZIkSZI0QjaFJK17SS4cegySJEljYwaTZp9NIUmrKsnzSZ6c+P+FJHuT7EvyVZKlJM9OLH87yddJjiV5fGL+mSTPJfkC2NHzx5AkSdpQzGCSurApJGm1HQQWAJJcAOwCTgFbgduAm4BtSe5q199TVduA7cDeJFe08zcBy1V1e1V92uP4JUmSNiIzmKSpXTT0ACTNlqr6McnpJDcDVwLfArcCD7SvAeZoAsonNCFkZzv/mnb+aeAc8GafY5ckSdqozGCSurApJGktvA48BlwFvAHcB7xUVa9NrpTkHuB+YEdVnU3yEXBxu/iPqjrX03glSZJmgRlM0lS8fEzSWngLeJDm16nFdtqTZA4gydVJNgOXAr+2YeQ6YH6oAUuSJM0AM5ikqXimkKRVV1V/JfkQ+K39pemDJNcDnyUBOAPsBg4BTyRZAk4Anw81ZkmSpI3ODCZpWqmqoccgaca0Nzf8Bni4qk4OPR5JkqQxMINJmpaXj0laVUluAH4ADhtGJEmS+mEGk9SFZwpJkiRJkiSNkGcKSZIkSZIkjZBNIUmSJEmSpBGyKSRJkiRJkjRCNoUkSZIkSZJGyKaQJEmSJEnSCNkUkiRJkiRJGqF/AENC7g4tKw7rAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABIUAAAHwCAYAAAA4m994AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAB7tklEQVR4nOzddZic5fn28fMaWXfNJrubjYe4bBQLxZ1SoECRUgqlTg1o3/ZXb2mpUaG4tbR4ixQtsFgCMaLEfePZZJOs2/3+sZN0CZFNsrPPyPdzHHNkZp5n5jn3nsida24x55wAAAAAAAAQX3xeBwAAAAAAAED3oygEAAAAAAAQhygKAQAAAAAAxCGKQgAAAAAAAHGIohAAAAAAAEAcoigEAAAAAAAQhygKAQAAAAAAxCGKQkAUM7PVZlZvZjVmtsnMHjSztA7Hy83seTPbYWbVZvahmf3czLJDxz9rZu/s856XmtkiM6s1sxVmdnyHYyeb2WIzqzOzN8ys90GyJZjZk6GMzsym7HP8pNB77DSz1Z34WQ94bWv3KzOrCt1+bWbW4fgoM3s7dK1KM/u/fV77/8xsrZntMrNHzSyjw/GFofbdc2sxs+cOlRcAAMQu+mCH915mdmIoy886PDfFzNr26Wdd3eF4opndH+qfbTKzbx4qK4DDR1EIiH7nOufSJI2SNFrSdyXJzCZLqpD0rqTBzrksSWdIapE0cn9vZGanSvqVpGskpUs6QdLK0LE8SU9L+oGkHEkzJT12iGzvSLpC0qb9HKuVdL+k7xzqB+zEta+XdEHo5xoh6RxJX+hw/B+S3gq99kRJXzSz80LHrpJ0paRjJfWUlCzpT3te6Jwb6pxLC7VxuqS1kp44VGYAABDz6IN14r3MLCjpdknv7+fwhj39rNDtoQ7HfiRpgKTekk6SdJOZnXGozAAOT8DrAAC6hnNuk5m9rPaOiST9WtIDzrlfdjhnraQfHuRtfizpJ86590KP13c4dqGkhc65JyTJzH4kaZuZDXbOLd5PniZJfwid27qf49MlTTezUzrx4x3q2ldL+q1zrjJ0/LeSrpN0Z+j1ZZIecc61SloR+mZuqKRnJZ0r6T7n3LrQa38l6XUz+6Jzrm6fHCdIKpD0VCcyAwCAOBDPfbBOvte3JL2i9j7U4bhK0jXOuR2SdpjZPZI+K+mlw3wfAAfBSCEgRphZsaQzJS03s1RJk3QYxQsz80sql5RvZstD06z+bGbJoVOGSpq753znXK2kFaHnw+1Q1/7I8dD9jrn+IOkqMwua2SC1t81/Q8csdFOHx4lq/2ZqX1dLejJ0fQAAgHjvgx1UaKrZ5yT95ACnFJjZZjNbZWa/D7WfQtPseurg/TsAXSDiikKheaNbzGxBJ84tDc1h/cDM5pnZWd2REYgw/zaz3ZLWSdqi9m+hstX+53vvkGFrX2enOjRP/fv7eZ9CSUFJF0k6Xv8bCr3n3DRJO/d5zU61D3EOt0Nde9/jOyWlme1dV+h5tf9c9ZIWq31k0IzQsRclfd7MyswsU9LNoedTOl7MzFJC7/HgUf80ABBhDrP/dYKZzbb2NdYu2ufY1Wa2LHS7+kDvAcQI+mCH9kdJP3DO1ezn2GK1/6xFkj4haayk33W47p5rHcl1AXRSxBWF1P4frs7OFf2+pMedc6MlXSrpjnCFAiLYBc65dElTJA2WlCdph6Q2tf8jK0lyzt0UmtP+L+1/6mh96Nc/Oec2Oue2qf0f5j3F1hpJGfu8JkPS7lCBdu8igV3zY33EAa99gOMZkmqcc87MctQ+zPgnkpIklUg63cy+FDr3fkn/VPvc/4WS3gg9X7nP9S6UtF3Sm0f7wwBABHpQne9/rVX7FI5/dHwy9PftDyVNkDRe0g9D3/YDsYo+2EGY2bmS0p1z+13/yDm3yTn3oXOuzTm3StJNai+M7bnunmsd1nUBHJ6IKwo5595S+3+89jKzfmb2kpnNsvYdhAbvOV3/+4siU9KGbowKRBTn3Jtq79T/JjS09321FzI6+/odai+EuAOcslAdFkcMDe/tp/Z55ms7LhJ4hD/CwRzw2vs7Hrq/51hfSa3OuYedcy2hdYceVaijFeqI/NA5V+acKw69br0+Opdfap869rBz7kDtAwBR63D6X8651c65eWr/j29Hp0t61Tm3PfRvyqvqfKEJiFpx3gc7mJMllYd2Dtsk6dOSbjSzZw5wvlNoSn+oTTbqwP07AF0k4opCB3C3pK8658ZK+rb+NyLoR5KuMLNKSS9I+qo38YCI8QdJp5rZKLV/2/I5M7vFzAqkvXPe+xzk9Q9I+qqZFYS+3b1R7VOvpPZvt4aZ2afMLEnS/0mat78FDvew9q1Ek0IPE8wsac+ULjPzhY4F2x9akpklHOCtDnXthyV908x6mVlPtS9o+GDo2NLQ+18eumYPtXdK5oZy5IT+42NmNkTt38z9xDm39z87oXY7SVLHHTEAINYdqP91IL3UPo1mj8rQc0A8+IPisA92iPf6gaSBap8iNkrtG3zco/Yd1vZsSV8a6oOVSLpVUseC0cOSvm9m2aGi9HViGj/Q5SK+KGRmaZImS3rCzOZIukv/G455maQHQ9/unyXpb2YW8T8TEC7Oua1q/wf0B865d9Q+P/sESUvNrFrt06gq1GHL9X38VNIMtRdSFkn6QNLPO7z3p0KPd6h9esClh4i0RO1DontJejl0v3fo2Amhxy9IKg3df2XPC81soZl9ppPXvkvSc5LmS1og6T+h5+Sc26X2b+u+EXrtnNA5Pw+9Ni+UoVbt6wvd75y7e5+f40pJ05xzKw7x8wJATDhE/+uAL9vPc4yuRFyI4z7YAd/LObc7NEVsk3NuU+hYrXNuz6jEMZKmqb0PNlXt/bOvdXjvH6p9Ues1ap++f5tzjp3HgC5mkTgTwszKJD3vnBtmZhmSljjnPtYRMbOFks7osJX0SkkTnXNbujUwAABAlOts/6vD+Q+Gzn8y9PgySVOcc18IPb5LUoVz7p9hDw8AAI5IxI+qCX3Lv8rMLpbaxySa2Z65pWvVPldVZnaM2heR3epJUAAAgBhxiP7Xgbws6bTQVI9sSaeFngMAABEq4kYKmdk/1b6Cf56kzWofNvi6pL+qfdhyUNKjzrmfhNb/uEftWxY6STc5517Z3/sCAABg/w6z/zVO7euMZEtqkLTJOTc09D6fk/S90Nv+3Dn3QHf+HAAA4PBEXFEIAAAAAAAA4Rfx08cAAAAAAADQ9SgKAQAAAAAAxKGA1wE6ysvLc2VlZZKk2tpapaamehsojtH+3uMz8Bbt7y3a31vhbP9Zs2Ztc87lh+XNcUQ69r8k/vx5jfb3Fu3vLdrfW7S/97zog0VUUaisrEwzZ86UJFVUVGjKlCneBopjtL/3+Ay8Rft7i/b3Vjjb38zWhOWNccQ69r8k/vx5jfb3Fu3vLdrfW7S/97zogzF9DAAAAAAAIA5RFAIAAAAAAIhDYS0KmVmWmT1pZovNbJGZTQrn9QAAAAAAANA54V5T6HZJLznnLjKzBEkpYb4eAAAAAAAAOiFsRSEzy5B0gqTPSpJzrklSU7iuBwAAAAAAgM4L5/SxvpK2SnrAzD4ws3vNjP3tAAAAAAAAIkA4p48FJI2R9FXn3PtmdrukWyT9oONJZna9pOslqbCwUBUVFZKkmpqavffR/Wh/7/EZeIv29xbt7y3aHwAAID6EsyhUKanSOfd+6PGTai8KfYRz7m5Jd0tSeXm5mzJliiSpoqJCe+6j+9H+3uMz8Bbt7y3a31u0PwAAQHwI2/Qx59wmSevMbFDoqZMlfRiu6wEAAAAAAKDzwr372FclPRLaeWylpGvCfD0AAAAAAAB0QliLQs65OZLKw3kNAAAAAAAAHL5w7j4GAACALmJm95vZFjNbcIjzxplZq5ld1F3ZAABAdKIoBAAAEB0elHTGwU4wM7+kX0l6uTsCAQCA6EZRCAAAIAo4596StP0Qp31V0lOStoQ/EQAAiHYUhQAAAGKAmfWS9ElJd3qdBQAARIdw7z4GAACA7vEHSTc751rN7KAnmtn1kq6XpMLCQlVUVOw9VlNT85HH6F60v7dof2/R/t6i/b3nxWcQt0Uh55wO1WECAACIIuWSHg31b/IknWVmLc65f+97onPubkl3S1J5ebmbMmXK3mMVFRXq+LirtbY5+X30wQ4k3O2Pg6P9vUX7e4v2954Xn0HcTR9rbXP61UuLNfLHr2jVtlqv4wAAAHQJ51wf51yZc65M0pOSvrS/gpBXahpb9LkHZ+ik31RoW02j13EAAIDirCi0s65Zn3twhv5asUK7Glr0r9mVXkcCAADoFDP7p6RpkgaZWaWZXWtmN5jZDV5nO5RNOxt08Z3T9ObSrdq0q0Ff+cdstbS2eR0LAIC4FzfTx5Zu3q3rH56p9dX1+vknh+mF+Rv17NwN+sapA5lGBgAAIp5z7rLDOPezYYxyWBZt3KXPPThDu+qbdf9nx6mqplHffHyufvXSYv2/s4d4HQ8AgLgWF0Whlxdu0jcfm6PkhID+ed1ElZflyG+mW56erwXrd2l4cabXEQEAAGLOW0u36kuPzFZaYkBP3DBZQ3pmSJLmrKvWPW+v0siSLJ0zoqfHKQEAiF8xP33sww279IW/zVL/wnQ9/9XjVF6WI0k6Y1gPBf2mZ+eu9zghAABA7Hlu7gZ97sEZKs5O1r++/L+CkCR9/+whGts7Wzc9OU9LN+/2MCUAAPEt5otCQ3pm6PZLR+mx6yeqR2bS3uezUhJ0woB8PT9vo9ranIcJAQAAYs8xRek6fVgPPXHDJBVlJn/kWELApzs+M0apiQF94W+ztKuh2aOUAADEt5gvCknS+aN6KSno/9jz543qqY07GzRzzQ4PUgEAAMSu/gXp+svlY5SeFNzv8cKMJN3xmTFat71O33t6fjenAwAAUpwUhQ7klGMKlRT06bm5G7yOAgAAEHfGleXoq58YoOfnbdT7K6u8jgMAQNyJ66JQamJAJx9TqBfmb2RbVAAAAA9cf0Jf9cxM0k+e/1CtTOkHAKBbxXVRSJLOHdFTVbVNmrqCb6cAAAC6W3KCXzefOVgLN+zSU7MrvY4DAEBcifui0JRB+UpPDDCFDAAAwCPnjeyp0aVZuu3lJappbPE6DgAAcSPui0JJQb9OG9pDLy3cpMaWVq/jAAAAxB0z0w/OGaKtuxv114rlXscBACBuxH1RSGrfhWx3Q4veXLLV6ygAAABxaUxpti4Y1VP3vL1KlTvqvI4DAEBcoCgkaXK/XOWkJuhZppABAAB45qYzBstn0q0vLvY6CgAAcYGikKSg36czh/XQa4u2qKmFXcgAAAC80DMrWV84oZ+en7dRj89Yp4ZmpvYDABBOFIVCjh+Qp/rmVi3YsNPrKAAAAHHrCyf21YCCNN301DyN+9l/9e0n5uqdZdvYrh4AgDAIeB0gUoztnSNJmrl6u8aUZnucBgAAID6lJAT00o0naNqKKv17znq9tGCTnpxVqYL0RH3vrGN0weheXkcEACBmMFIoJD89UX3yUjVj9Q6vowAAAMQ1v8903IA8/ebikZr5/VP018+MUa/sZN342Bx9/dEPtLO+2euIAADEBEYKdVDeO1v/XbRZzjmZmddxAAAA4l5S0K8zhxfp1CGFuqNihW5/bZlmrt6h3396lMb3yTnoa1vbnFZX1WrFlhqt3V6n1VW1WlNVp407G3RJebGuP6FfN/0UAABEJopCHYwry9ETsyq1Ymut+hekeR0HAAAAIQG/T187eYCOH5CnGx+bo0vvnqarJpWpX0Gagj5TwO9T0G/a1dCiRRt36cMNu7Rk027Vd1isOjM5qN65KUpLDOgXLyxWm5NuOJHCEAAgflEU6qC8rH0toZmrt1MUAgAAiECjS7P1n68dr588t1APTl2933Myk4M6pihdl40v1TFF6RpYmK7euSnKSkmQ1D6C6MbH5ujWFxcrwe/T547r040/AQAAkYOiUAd98lKVm5qgGat36NLxpV7HAQAAwH6kJQb064tG6vvnDFFDc6taWp1aWp2a29qUHPSrKDPpoEsB+H2m310yUk0trfrJ8x8qIeDTFRN7d+NPAABAZKAo1IGZqbwsWzPXbPc6CgAAAA4hIymojKTgEb026PfpT5eN0Q1/n6Xv/3uBEgI+XVJe0sUJAQCIbOw+to9xZTlaU1WnLbsavI4CAACAMEoI+HTHZ8bo+AF5uvmpefrev+ZrbVWd17EAAOg2FIX2UV7WvovFzDVsTQ8AABDrkoJ+3X1luT4zoVRPzqzUSb+t0Dcem6Nlm3d7HQ0AgLCjKLSPoT0zlBT0acZqppABAADEg+QEv352wXC9ddNJumZymV5asEmn/v4tffHvs1Rd1+R1PAAAwoai0D6Cfp9Gl2Rr5mpGCgEAAMSTHplJ+v45Q/TuLZ/Q1z7RX68t2qJL7pqmTTtZVgAAEJsoCu3HuLJsLdywUzWNLV5HAQAAQDfLSU3QN08bpAc/N04bqhv0qb9O1cqtNV7HAgCgy1EU2o/yshy1OemDtYwWAgAAiFeT++Xp0esnqqG5VRffOU3zK3d6HQkAgC5FUWg/RpdmyWfSDKaQAQAAxLVhvTL1xA2TlBT067J73tPUFdu8jgQAQJehKLQf6UlBHVOUoZksNg0AABD3+uan6akvTlbPrCRd99BMbd3d6HUkAAC6BEWhAxhXlqMP1larubXN6ygAAADwWI/MJN11ZbkaWtr0p9eXeR0HAIAuQVHoAMrLslXf3KoPN+zyOgoAAAAiQJ+8VF02vkT/eH+tVm+r9ToOAABHjaLQAZT3zpEkzWAKGQAAAEK+dvIABf0+/eaVJV5HAQDgqFEUOoAemUkqyUnW+6soCgEAAKBdQXqSrju+j56ft1Fz11V7HQcAgKNCUeggzhjaQ/9dtJnRQgAAANjruhP6Kjc1Qbe+uFjOOa/jAABwxCgKHcSNpwxUcXayvvPEXNU3tXodBwAAABEgPSmor36iv6atrNJby9iiHgAQvSgKHURqYkC//tRIra6q020vM28cAAAA7S6f0FslOcm69cXFamtjtBAAIDpRFDqESf1yddWk3npg6ipNZ30hAAAASEoI+PTt0wZp0cZdenbuBq/jAABwRCgKdcLNZwxWcXaybnqSaWQAAABod+6InhpSlKG/vLGctYUAAFGJolAndJxG9uuXF3sdBwAAABHA5zNdMbG3lm2p0bzKnV7HAQDgsFEU6qQ908genLqaaWQAAACQJJ09okiJAZ+eml3pdRQAAA4bRaHDcPMZg9UzM1k/f2ERQ4QBAACgzOSgThvaQ8/M2aDGFpYZAABEF4pChyE1MaAvn9Rfc9dV693lVV7HAQAAQAS4aGyxdtY36/VFW7yOAgDAYaEodJg+NbaXemQk6U+vL/M6CgAAACLAcf3zVJiRqCdnMYUMABBdKAodpsSAX9ef0Ffvr9quGatZWwgAACDe+X2mT44uVsXSrdq6u9HrOAAAdBpFoSNw2fhS5aYm6M+vL/c6CgAAACLARWN7qbXN6Zk5672OAgBAp1EUOgLJCX5de3wfvbl0q+ZVVnsdBwAAAB7rX5CukSVZenJWJRuSAACiBkWhI3TlxN7KSAroL28wWggAAADSRWN6afGm3Vq4YZfXUQAA6BSKQkcoPSmozx7bRy8v3Kwlm3Z7HQcAAAAeO3dkTyX4fXpqNgtOAwCiA0Who3DN5DKlJvgZLQQAAABlpSTolCEFembOBjW1tHkdBwCAQ6IodBSyUxN0xcTeen7eBv37g/WqqmG3CQAAEB5mdr+ZbTGzBQc4/hkzmxe6TTWzkd2dEdJFY4u1vbZJry/e4nUUAAAOKeB1gGh37fF99MycDbrxsTmSpIGFaZrYN1fHD8jXKccUyMy8DQgAAGLFg5L+LOnhAxxfJelE59wOMztT0t2SJnRTNoScMCBfvbKS9YNnFmhQj3T1yUv1OhIAAAfESKGjVJCepLdvPklPf2mybjpjkHpkJuvJWZW67uGZ+hNb1gMAgC7inHtL0vaDHJ/qnNsReviepOJuCYaPCPh9evCacWptc7r8nve0bnud15EAADggikJdIOj3aUxptr40pb8e/tx4zf3habpwdC/97tWlen7eBq/jAQCA+HOtpBe9DhGvBhSm6+/XTlBdU6suv/c9bdxZ73UkAAD2K6zTx8xstaTdkloltTjnysN5vUgR9Pv0y08N19rtdfrW43NVnJ2iUSVZXscCAABxwMxOUntR6LiDnHO9pOslqbCwUBUVFXuP1dTUfOQxjtzXR/l124x6ffL2N3TLhCRlJR76+1ja31u0v7dof2/R/t7z4jPojjWFTnLObeuG60SUxIBfd105Vhfc8a4+/9BMPfuVY9UzK9nrWAAAIIaZ2QhJ90o60zlXdaDznHN3q33NIZWXl7spU6bsPVZRUaGOj3HkpkgaMXK7rrp/uv6y0K9Hr5+o3LTEg76G9vcW7e8t2t9btL/3vPgMmD4WRrlpibrv6nFqbG7VtQ/NVG1ji9eRAABAjDKzUklPS7rSObfU6zxoV16Wo/uuHqe12+t0xX3TVV3X5HUkAAD2CvdIISfpFTNzku4KfSv1EQcavhxLQ9euG+bX72ft0mV//q++ODJRyYHI35Eslto/WvEZeIv29xbt7y3aPzKZ2T/VPvgkz8wqJf1QUlCSnHN3Svo/SbmS7gjtfho3U/cj3aR+ubrnqnJ9/uGZuuK+9/XItROVmRL0OhYAAGEvCh3rnNtgZgWSXjWzxaGdM/Y60PDlWBq6NkVSTska/eCZBfrFbKffXTJS48pyvI51ULHU/tGKz8BbtL+3aH9v0f6RyTl32SGOf17S57spDg7TCQPzddcVY/WFv83SVfe/r799foIykigMAQC8FdbpY865DaFft0j6l6Tx4bxeJLtiYm89/oVJMpkuuWuafvniIjW2tHodCwAAAN3kpMEFuuMzY7Rwwy599v7pqmFpAQCAx8JWFDKzVDNL33Nf0mmSFoTretFgXFmOXvj68bp0XInuenOlzv/zu1qyabfXsQAAANBNThlSqD9fPlpzK3fqmgema3dDs9eRAABxLJwjhQolvWNmcyVNl/Qf59xLYbxeVEhLDOiXF47QfVeXa1tNkz734Ay1tLZ5HQsAAADd5IxhRfrjpaM1e221Lr/nfW2rafQ6EgAgToWtKOScW+mcGxm6DXXO/Txc14pGJx9TqF98cpjWV9fr1Q83ex0HAAAA3ejsEUW656qxWrZlty65c5oqd9R5HQkAEIfYkt5DJx9TqOLsZD0wdbXXUQAAANDNPjG4UH+/doK21TTqU3+dqqWbWVYAANC9KAp5yO8zXT2pTNNXbdfCDTu9jgMAAIBuVl6Wo8dvmCTnpIvvnKblO9iIBADQfSgKeeyS8hIlB/16iNFCAAAAcWlwjww99cXJykoJ6tczGlhaAADQbSgKeSwzJagLx/TSv+ds0PbaJq/jAAAAwAMlOSl68obJ6pXm0xf+NlN/e2+N15EAAHGAolAE+OzkMjW1tOmf09d6HQUAAAAeyU9P1C3jkzRlUIF+8O8F+tVLi9XW5ryOBQCIYRSFIsCAwnQd1z9Pf39vjZrZnh4AACBuJQZMd185VpeNL9VfK1bom4/PUVML/UMAQHhQFIoQn51cpo07G/TKQuaQAwAAxLOA36dffHKYvnP6IP17zgbd8PdZjBgCAIQFRaEIcdLgApXmpOjBqau8jgIAAACPmZm+fFJ//ejcIXp98RbdUbHc60gAgBhEUShC+H2mqyb11ozVO7RgPdvTAwAAQLp6cpnOG9lTv3t1qaatqPI6DgAgxlAUiiAXl5coJcGvP7/ON0EAAABoHzH0iwuHqyw3VV979ANt3d3odSQAQAyhKBRBMpOD+vJJ/fXSwk169UPWFgIAAICUlhjQXz4zRrvqm3XjYx+olfWFAABdhKJQhLn+hL4a3CNdP/j3Au1uaPY6DgAAACLAMUUZ+un5w/Tu8ir98bVlXscBAMQIikIRJuj36ZcXDtfm3Q36zctLvI4DAACACHFxebEuHNNLf3x9md5Zts3rOACAGEBRKAKNLs3W1ZPK9PB7azRrzQ6v4wAAACACmJl+dsEw9c9P09cf/UAbd9Z7HQkAEOUoCkWob58+SEUZSfru0/PU1NLmdRwAAABEgJSEgP56xVg1NLfqS4/Mpp8IADgqFIUiVFpiQD85f5iWbq7RXW+u8DoOAAAAIkT/gjTddvFIfbC2Wr94YZHXcQAAUYyiUAQ7ZUihzh5epD+9vlwrt9Z4HQcAAAAR4qzhRfr8cX304NTVembOeq/jAACiFEWhCPfD84bI55PufWeV11EAAAAQQW4+c7DGlWXrlqfma+nm3V7HAQBEIYpCEa4gPUlnDS/Ss3M2qK6pxes4AAAAiBBBv09/uXyMUhMDuuFvs7S7odnrSACAKENRKApcOq5UNY0temH+Jq+jAAAAIIIUZCTpL5eP1uqqWtYXAgAcNopCUWBcWbb65qXqsRlrvY4CAACACDOhb66uO76v/jl9naau2OZ1HABAFKEoFAXMTJ8eV6IZq3do+RYWnAYAAMBH3XjKQJXlpui7T89XfVOr13EAAFGColCUuHBMsQI+0+Mz13kdBQAAABEmOcGvX144Qmuq6vT7/y71Og4AIEpQFIoS+emJOvmYAj01q1JNLW1exwEAAECEmdQvV5dPKNW9b6/U3HXVXscBAEQBikJR5NJxpaqqbdJrizZ7HQUAAAAR6JYzB6sgPUk3PzWPLxIBAIdEUSiKnDAwXz0ykvQYU8gAAACwHxlJQf3sgmFavGm37nxzhddxAAARjqJQFPH7TJeUF+vNpVu1obre6zgAAACIQKcMKdR5I3vqT68v09LNu72OAwCIYBSFoszF5SVyTnpiZqXXUQAAABChfnjuEKUnBfWdJ+aqpZVpZACA/aMoFGVKclJ0XP88PT5znVrbnNdxAAAAEIFy0xL10/OHaW7lTt3z9iqv4wAAIhRFoSh0ybgSra+u1/RV272OAgAAgAh19oginTmsh37/6lItYxoZAGA/KApFoU8MLlDQb3pjyRavowAAACCC/eT8YUpN9Os7T85jlDkA4GMoCkWhtMSAxvfJ0RuLKQoBAADgwPLTE/Xj84dpzrpq3ffOSq/jAAAiDEWhKHXSoAIt21KjddvrvI4CAACACHbuiCKdPrRQv3llqZZvqfE6DgAgglAUilInDS6QJFUwhQwAAAAHYWb66QXDlJLg17efmKvGllavIwEAIgRFoSjVNy9VvXNT9MaSrV5HAQAAQIQrSE/Szy8YrjnrqvWtx+eqjfWFAACiKBS1zEwnDSrQ1BXb1NDMtz0AAAA4uLNHFOm7Zw7W8/M26qf/+VDOURgCgHhHUSiKnTS4QA3NbZq2ssrrKAAAAIgC15/QV587to8eeHe17n6LhacBIN5RFIpiE/rkKDnoZxcyAAAAdIqZ6ftnH6NzRhTply8u1tOzK72OBADwEEWhKJYU9OvY/rl6ffEWhv8CAACgU3w+028vGanJ/XJ105Pz9OZS1qgEgHhFUSjKTRlUoMod9VqxtdbrKAAAAIgSiQG/7rpyrAYUpusbj83RzrpmryMBADxAUSjK7dmanilkAAAAOBzpSUHddtEI7ahr0h9eW+p1HACABygKRbleWckaVJiuN5ZQFAIAAMDhGdYrU5eNL9XD09Zo2ebdXscBAHQzikIx4KTBBZqxert2NzDsFwAAAIfn26cNUmqCXz95nm3qASDeUBSKAScNyldzq9O7y7d5HQUAAABRJic1Qd84daDeXrZNr3642es4AIBuRFEoBoztna30pIDeWMzOEQAAxCozu9/MtpjZggMcNzP7o5ktN7N5ZjamuzMiel0xsbcGFqbpZ/9ZpIbmVq/jAAC6CUWhGBDw+3TCwHy9sYSt6QEAiGEPSjrjIMfPlDQgdLte0l+7IRNiRNDv0w/PHaq12+t03zurvI4DAOgmFIVixKS+udqyu1EbdjZ4HQUAAISBc+4tSdsPcsr5kh527d6TlGVmRd2TDrHg2P55On1oof7yxnJtok8JAHGBolCMGFiYLklayq4RAADEq16S1nV4XBl6Dui07589RC1tTjc/NU+tbYxAB4BYF/A6ALrGwMI0SdKyzbt10qACj9MAAAAP2H6e2+//6s3serVPMVNhYaEqKir2HqupqfnIY3SvSGj/ywYG9NCHW/XFu17R5cckepqlu0VC+8cz2t9btL/3vPgMKArFiKyUBOWnJ2rp5hqvowAAAG9USirp8LhY0ob9neicu1vS3ZJUXl7upkyZsvdYRUWFOj5G94qE9p8iyffcQj3w7mpNGXOMLp9Q6mme7hQJ7R/PaH9v0f7e8+IzYPpYDBlYmKZlTB8DACBePSvpqtAuZBMl7XTObfQ6FKLT/zvrGJ04MF//98wCTV2xzes4AIAwoSgUQwYUpGvZlhq1Mf8bAICYY2b/lDRN0iAzqzSza83sBjO7IXTKC5JWSlou6R5JX/IoKmJAwO/Tny4frT55qfri32dr5VZGowNALKIoFEMGFqarrqlV66vrvY4CAAC6mHPuMudckXMu6Jwrds7d55y70zl3Z+i4c8592TnXzzk33Dk30+vMiG4ZSUHdd/U4+X2mzz80Uzvrmr2OBADoYhSFYsjexaa3MIUMAAAAR680N0V3XTlWa7bX6ff/Xep1HABAF6MoFEMG7N2WnuG9AAAA6BrjynJ0SXmJHnl/jSp31HkdBwDQhSgKxZDM5KAKMxK1lMWmAQAA0IW+dnJ/mZlu/+8yr6MAALoQRaEYM7AwXcsYKQQAAIAuVJSZrKsm9tZTsyu1fAt9TQCIFRSFYsyAgnQtZwcyAAAAdLEvndRfyUG/fvfqEq+jAAC6CEWhGDOwME31za2q3MEOZAAAAOg6OakJ+vzxffXC/E2aX7nT6zgAgC5AUSjG/G+xadYVAgAAQNf6/PF9lJUS1G9eYbQQAMSCsBeFzMxvZh+Y2fPhvhakAaFt6ZeyLT0AAAC6WHpSUF+a0k9vLt2q91dWeR0HAHCUumOk0NclLeqG60BSRlJQRZlJWrqJohAAAAC63lWTylSYkajbXl4i51jHEgCiWViLQmZWLOlsSfeG8zr4qAGF6VrKDmQAAAAIg6SgX187eYBmrtmhF+Zv8joOAOAoBML8/n+QdJOk9AOdYGbXS7pekgoLC1VRUSFJqqmp2Xsfhye5qVHLNrfo9TfekM/siN6D9vcen4G3aH9v0f7eov0BHMqny0v0z+lr9aPnFuq4AXnKTA56HQkAcATCVhQys3MkbXHOzTKzKQc6zzl3t6S7Jam8vNxNmdJ+akVFhfbcx+HZkrpOL6+epz7Dx6tPXuoRvQft7z0+A2/R/t6i/b1F+wM4lIDfp1svHKHz/vyOfv3SYv38k8O9jgQAOALhnD52rKTzzGy1pEclfcLM/h7G6yFk72LT7EAGAACAMBnWK1OfO7aPHnl/rWas3u51HADAEQhbUcg5913nXLFzrkzSpZJed85dEa7r4X/2bEu/jKIQAAAAwugbpw5Ur6xkfffp+WpsafU6DgDgMHXH7mPoZmmJAfXKSmaxaQAAAIRVamJAP7tgmJZvqdFdb670Og4A4DB1S1HIOVfhnDunO66FdgMK05g+BgAAgLA7aXCBzh3ZU39+fblWbOVLSQCIJowUilEDC9O1cmutWlrbvI4CAACAGPd/5wxRUtCn7z09X845r+MAADqJolCMGlCQpqbWNq3ZXud1FAAAAMS4/PREfeu0QXp/1XZ9sK7a6zgAgE6iKBSjBrLYNAAAALrRp8YWKyXBr3++v9brKACATqIoFKP6F+zZlp553QAAAAi/tMSAzh/VU8/N26BdDc1exwEAdAJFoRiVmhhQcXYyi00DAACg21w+vrcamtv07w/Wex0FANAJFIVi2OAe6fpgbbVa21jsDwAAAOE3vDhTw3pl6B/vr2XBaQCIAhSFYtiFY4q1vrpeLy/c5HUUAAAAxInLxpdq8abdmsOC0wAQ8SgKxbDTh/ZQn7xU/bViBd/UAAAAoFucP6qXUhL8+gcLTgNAxKMoFMP8PtP1J/TV/PU79e7yKq/jAAAAIA6w4DQARA+KQjHuwjG9VJCeqDvfXOF1FAAAAMSJy8aXqqG5Tc+w4DQARDSKQjEuMeDX547ro3eWb9O8ymqv4wAAACAOjCjO0rBeGXqEBacBIKJRFIoDn5lQqvSkAKOFAAAA0G1YcBoAIh9FoTiQnhTUlRN768UFm7RqW63XcQAAABAHzhvZUykJfj3CgtMAELEoCsWJa47to6Dfp7vfYrQQAAAAwi89KahLykv09OxKRgsBQISiKBQn8tMTdfHYYj01a7227GrwOg4AAADiwDdPG6jCjCTd9ORcNba0eh0HALAPikJx5PoT+qqlrU33vbvK6ygAAACIAxlJQf3ik8O1dHON/vIGI9YBINJ0uihkZqlm5g9nGIRX79xUnT60hx6dvk71TXxTAwCAl+hbIV6cNLhAF47upTveWK4PN+zyOg4AoIMDFoXMzGdml5vZf8xsi6TFkjaa2UIzu83MBnRfTHSVqyeXaWd9s56Zs97rKAAAxBX6VohnPzhniLJSgrrpqblqaW3zOg4AIORgI4XekNRP0ncl9XDOlTjnCiQdL+k9Sbea2RXdkBFdaEKfHA3uka4Hp66Wc87rOAAAxBP6Vohb2akJ+sn5w7Rg/S7d/fZKr+MAAEICBzl2inOued8nnXPbJT0l6SkzC4YtGcLCzHT15DJ99+n5mr5quyb0zfU6EgAA8YK+FeLaWcOLdOawHvrDf5fptCE91L8gzetIABD3DjhSaH+dFjPLOdQ5iHwXjOqlzOSgHpq22usoAADEDfpWgPTj84cqJcGvL/59lnbW8dsdALx2sDWFjjWzRaF57hPM7FVJM81snZlN6saM6GLJCX59elyJXl64WRt31nsdBwCAuEDfCpAK0pN0x2fGaHVVra7720w1NLP5CQB46WBrCv1e0iWSPi/pP5J+7JzrK+l8Sb/phmwIoysn9labc3rkvbVeRwEAIF7QtwIkTe6Xp99eMkrTV23XNx+fo9Y21rkEAK8crCgUdM7Nd85Nk7TVOfeOJDnnZktK7pZ0CJuSnBSdPLhQ/5y+lm9oAADoHvStgJDzRvbU988+Ri/M36SfPv8hG6AAgEcOVhTqeOy7+xxLCEMWdLOrJ/dWVW2T/jNvo9dRAACIB/StgA4+f3xfff64Pnpw6mrd9RY7kgGAFw5WFPqBmaVIknPu33ueNLN+kh4Ocy50g+P656lffqoemsb29AAAdAP6VsA+vnfWMTp3ZE/d+uJivTCfLyoBoLsdbPexZ51zdft5foVz7tfhjYXusGd7+nmVO/XBumqv4wAAENPoWwEf5/OZfnPxCI0sydItT83Thmo2QQGA7nSwkUKSJDMrN7N/mdlsM5u359Yd4RB+F44pVnpiQA+8u9rrKAAAxAX6VsBHJQb8uv3To9TS5vStx+eqjYWnAaDbHLIoJOkRSQ9I+pSkczvcEAPSEgP69LgSvTB/I9vTAwDQPehbAfsoy0vVD88domkrq3TvO6wvBADdpTNFoa2h4c6rnHNr9tzCngzd5urJZXLO6aGpfKwAAHQD+lbAflxSXqLThxbqtpeXaOGGnV7HAYC40Jmi0A/N7F4zu8zMLtxzC3sydJuSnBSdPrSH/jl9reqaWryOAwBArKNvBeyHmenWC0coOyVBX390jhqaW72OBAAxrzNFoWskjZJ0hv43vPmcMGaCB649ro921jfrqdnrvY4CAECso28FHEB2aoJ+e8lILd9So1tfXOx1HACIeYFOnDPSOTc87EngqbG9szWiOFMPvLtKnxlf6nUcAABi2RH3rczsDEm3S/JLutc5d+s+xzMl/V1Sqdr7eb9xzj1wlHmBbnX8gHx97tg+uv/dVUoM+PTN0wYqMeD3OhYAxKTOjBR6z8yGhD0JPGVmuva4Plq5tVZvLt3qdRwAAGLZEfWtzMwv6S+SzpQ0RNJl+3mfL0v60Dk3UtIUSb81s4SjzAt0u5vPHKTLJ5TqrrdW6oK/TNXSzbu9jgQAMakzRaHjJM0xsyWhLVPns21qbDpreJEKMxJ1/7urvI4CAEAsO9K+1XhJy51zK51zTZIelXT+Puc4SelmZpLSJG2XxIKBiDqJAb9+8cnhuveqcm3Z1aBz/vSOHnh3FdvVA0AX68z0sTPCngIRIej36apJZbrt5SU6vSDZ6zgAAMSqI+1b9ZK0rsPjSkkT9jnnz5KelbRBUrqkTzvn2o7weoDnThlSqJdKTtDNT83Tj5/7UG8v26a7rxyrgL8z320DAA7lgEUhM0tzztUcbIvUPeeEJxq8cPn4Uv3p9WV6ZU2zrvA6DAAAMaQL+la2n+f2HTZxuqQ5kj4hqZ+kV83sbefcrn2uc72k6yWpsLBQFRUVe4/V1NR85DG6F+2/f1f2dipwCXp08RZ9/+HXdEafYFiuQ/t7i/b3Fu3vPS8+g4ONFHrGzOZIekbSLOdcrSSZWV9JJ0m6RNI9kp4Md0h0n+zUBF04pliPz1irqppG5aYleh0JAIBYcbR9q0pJJR0eF6t9RFBH10i61TnnJC03s1WSBkua3vEk59zdku6WpPLycjdlypS9xyoqKtTxMboX7X9gU5zT1odm6pkVVfrqJ49Tr6yuH9lO+3uL9vcW7e89Lz6DA467dM6dLOk1SV+QtNDMdppZldp3tOgh6WrnHAWhGHTN5DK1tElPza70OgoAADGjC/pWMyQNMLM+ocWjL1X7VLGO1ko6WZLMrFDSIEkru/YnAbxhZvrx+UMlST98ZoHaa58AgKNx0DWFnHMvSHqhm7IgQgwoTNeALJ8enbFO1x3fV+1rVQIAgKN1NH0r51yLmX1F0stq35L+fufcQjO7IXT8Tkk/lfSgmc1X+3Szm51z27omPeC94uwUffPUgfr5C4v08sLNOmNYD68jAUBU68xC04hDJ5YEdO/8Ws1YvUPj++R4HQcAAGj/RaVQMWjP/Q2STuvuXEB3uubYMj39wXr96NmFOrZ/rtKTwrO+EADEA5btx36NKwwoPTGgR6ev9ToKAAAAsFfA79MvLxyuzbsb9NtXlnodBwCiGkUh7FdiwHTeqJ76z/yN2lnf7HUcAAAAYK9RJVm6cmJvPTRtteZVVnsdBwCiVqeKQmZ2nJldE7qfb2Z9whsLkeCy8aVqbGnTM3PWex0FAICYQt8KOHrfPn2Q8tMSdfNT89XY0up1HACISocsCpnZDyXdLOm7oaeCat8lAzFuWK9MDe2ZoX9OX8fuDgAAdBH6VkDXyEgK6hefHK5FG3fpNy8v8ToOAESlzowU+qSk8yTVSnsXMEwPZyhEjkvHl2rRxl2av36n11EAAIgV9K2ALnLKkEJdMbFU97y9Sm8v2+p1HACIOp0pCjW59mEiTpLMLDW8kRBJzh/VU0nB9u3pAQBAl6BvBXSh/3fWEPUvSNO3Hp+r7bVNXscBgKjSmaLQ42Z2l6QsM7tO0n8l3RPeWIgUGUlBnT28p56ds0G1jS1exwEAIBbQtwK6UHKCX3+8dLSq65p105PzWPYAAA7DIYtCzrnfSHpS0lOSBkn6P+fcn8IdDJHj0vElqmls0X/mb/Q6CgAAUY++FdD1hvTM0E1nDNJ/F23WP6av9ToOAESNQGdOcs69ambv7znfzHKcc9vDmgwRo7x3tvrlp+rR6Wt1SXmJ13EAAIh69K2Arve5Y/vozaVb9dPnP9SEPjnqX8BSXQBwKJ3ZfewLZrZZ0jxJMyXNCv2KOGFmunRcqWavrdbyLbu9jgMAQFSjbwWEh89n+u3FI5WSENC1D83Ull0NXkcCgIjXmTWFvi1pqHOuzDnX1znXxznXN9zBEFnOH91Tfp/pqdnrvY4CAEC0o28FhElBRpLuvbpcW3c36or73mfhaQA4hM4UhVZIqgt3EES2gvQknTgwX0/PrlRrG4v3AQBwFOhbAWE0pjRb915drjVVdbr6/una3dDsdSQAiFidKQp9V9JUM7vLzP645xbuYIg8nxpTrM27GvXu8m1eRwEAIJrRtwLCbHK/PP31ijFatHGXrn1wpuqbWr2OBAARqTNFobskvS7pPbXPed9zQ5w5+ZgCZSQF9NTsSq+jAAAQzehbAd3gE4ML9YdLR2nmmu26/m8z1dhCYQgA9tWZ3cdanHPfDHsSRLykoF/njuypp2ZXandDs9KTgl5HAgAgGtG3ArrJOSN6qq6pVTc9OU8/e36RfnrBMK8jAUBE6cxIoTfM7HozKzKznD23sCdDRLpobLEamtv0wvyNXkcBACBa0bcCutEl5SX6/HF99Lf31uiNJVu8jgMAEaUzRaHLFZr7rv8Nb2bb1Dg1qiRLffNT9dQsdiEDAOAI0bcCutm3Tx+kQYXpuunJeexIBgAdHLIoFNomdd8b26bGKTPTp8YUa/rq7VpTVet1HAAAog59K6D7JQX9+v2nR2lnXbO+9/R8OcduugAgdWJNITO7an/PO+ce7vo4iAYXjuml37yyRE/NXq9vnjrQ6zgAAEQV+laAN4b0zNC3ThuoX764WE/OqtTF5SVeRwIAz3Vm+ti4DrfjJf1I0nmHepGZJZnZdDOba2YLzezHR5UUEaMoM1nH9svT07Mr1dbGtywAABymI+pbATh6nz++ryb0ydGPn/tQ67bXeR0HADzXmeljX+1wu07SaEkJnXjvRkmfcM6NlDRK0hlmNvGo0iJiXDS2WJU76jV99XavowAAEFWOom8F4Cj5fabfXjJSJukbj81RK19wAohznRkptK86SQMOdZJrVxN6GAzd+Fs3Rpw+tIfSEgN6alal11EAAIh2nepbAegaxdkp+skFQzVzzQ7d/dZKr+MAgKc6s6bQc/pfMccnaYikxzvz5mbmV/uOGv0l/cU59/5+zrle0vWSVFhYqIqKCklSTU3N3vvofp1p/9F50nNzKnVqznYl+K17gsUR/gx4i/b3Fu3vLdo/vI6mbwWga1wwqpdeWbhZv391qU4anK/BPTK8jgQAnjhkUUjSbzrcb5G0xjnXqeEhzrlWSaPMLEvSv8xsmHNuwT7n3C3pbkkqLy93U6ZMkSRVVFRoz310v860v/Xcqrfvny4rGqIpQwq7J1gc4c+At2h/b9H+3qL9w+6I+1YAuoaZ6WcXDNOM1W/rG4/N1TNfPlYJgSOZRAEA0a0zawq92eH27pF0Wpxz1ZIqJJ1x+BERqSb3y1VWSlD/mbfB6ygAAESNruhbATh6uWmJuvXC4Vq0cZduf22p13EAwBMHHClkZru1/zWATO1LBh10jKWZ5Utqds5Vm1mypFMk/epowiKyBP0+nTG0h56bu0ENza1KCvq9jgQAQMQ62r4VgK53ypBCXTy2WH+tWKGTj2HkO4D4c8CRQs65dOdcxn5u6Z3stBRJesPM5kmaIelV59zzXRUckeHsEUWqbWrVm0u3eh0FAICI1gV9KwBh8H/nDlFRZrK+9fhcNbawLw6A+NKpibNmNtLMvhK6jejMa5xz85xzo51zI5xzw5xzPzm6qIhEk/rmKjslqP/M2+h1FAAAosaR9K0AhEd6UlC3XTxCq7bV6vGlTV7HAYBudciikJl9XdIjkgpCt0fM7KvhDoboEPD7dMawIv130WY1NLd6HQcAgIhH3wqIPJP75elzx/bRa2tb9Jc3lnsdBwC6TWdGCl0raYJz7v+cc/8naaKk68IbC9HknBFFqmtqVcWSLV5HAQAgGtC3AiLQd88arElFft328hLd+uJiOcdUMgCxrzNFIZPUcQhIa+g5QJI0oU+OclMT9DxTyAAA6Az6VkAECvp9um5Eoj4zoVR3vrlCP3hmgdraKAwBiG0H3H2sgwckvW9m/wo9vkDSfWFLhKjTPoWsh56evV71Ta1KTmAXMgAADoK+FRChfGb62QXDlJYY0F1vrVRdY6t+fdEIBfydWooVAKLOIf92c879TtI1krZL2iHpGufcH8KcC1Hm7BFFqm9u1RtMIQMA4KDoWwGRzcx0y5mD9e3TBurpD9brhr/PVm1ji9exACAsOrPQ9O2Skpxzf3TO3e6c+6AbciHKTOiTq7y0BHYhAwDgEOhbAZHPzPSVTwzQT84fqtcXb9aFd0zV2qo6r2MBQJfrzDjI2ZK+b2bLzew2MysPdyhEH7/PdOawIr22eLPqmvgmBQCAg6BvBUSJqyaV6aHPjdemXQ067y/vaOrybV5HAoAu1ZnpYw85586SNF7SUkm/MrNlYU+GqHP2iCI1NLfp9cVMIQMA4EDoWwHR5fgB+Xrmy8cqPy1RV94/XQ9NXc3OZABixuGsmNZf0mBJZZIWhyUNotq4shzlpSXq5YWbvY4CAEA0oG8FRImyvFT968vH6hODC/TDZxfqq//8QFt2N3gdCwCOWmfWFNrz7dVPJC2QNNY5d27YkyHq+H2mCX1zNHvNDq+jAAAQsehbAdEpLTGgu64Yq2+fNlCvLNysk3/7pv42bbVa2bYeQBTrzEihVZImOefOcM494JyrDnMmRLHRJVlaX12vzbv45gQAgAOgbwVEKZ+vfQHql248XiOKM/WDZxbqwjve1YL1O72OBgBHpDNrCt3pnGNFNXTK6NJsSdIHa6u9DQIAQISibwVEv775afr7tRN0+6WjtL66Qef9+R39+qXFamlt8zoaAByWw1lTCDikoT0zFPSbPljHFDIAAADELjPT+aN66bVvnaiLxhbrjooV+vTd72l9db3X0QCg0ygKoUslBf0a2jOTkUIAAACIC5nJQf36opG6/dJRWrJpt878w1t6eeEmr2MBQKcctChkZj4zW9BdYRAbRpdmaV5lNcNnAQDYB30rIHadP6qX/vO141SWl6ov/G2WfvjMAjXTHwYQ4Q5aFHLOtUmaa2al3ZQHMWB0abYamtu0eNNur6MAABBR6FsBsa13bqqevGGyrj2ujx6atkZ3vbnC60gAcFCBTpxTJGmhmU2XVLvnSefceWFLhag2uiRLkvTBumoN65XpbRgAACIPfSsghiUEfPrBOUO0cWe9/vj6cp09oqf65KV6HQsA9qszRaEfhz0FYkpxdrLy0hL1wdodunJib6/jAAAQaehbAXHgh+cO1dtLt+n//Wu+Hvn8BJmZ15EA4GM6syX9m5JWSwqG7s+QNDvMuRDFzEyjS7M0h8WmAQD4GPpWQHwozEjSTWcO1tQVVfrXB+u9jgMA+3XIopCZXSfpSUl3hZ7qJenfYcyEGDC6NEsrt9VqR22T11EAAIgo9K2A+PGZ8aUaXZqln/1nkbbTLwYQgTqzJf2XJR0raZckOeeWSSoIZyhEv9El2ZKkOeuqvQ0CAEDkOeK+lZmdYWZLzGy5md1ygHOmmNkcM1toZm92WWoAh83nM/3ywuHaVd+sX7ywyOs4APAxnSkKNTrn9pa1zSwgyYUvEmLByJJM+Uz6YO0Or6MAABBpjqhvZWZ+SX+RdKakIZIuM7Mh+5yTJekOSec554ZKurgLcwM4AoN7ZOi6E/rqyVmVmrpim9dxAOAjOlMUetPMvicp2cxOlfSEpOfCGwvRLiUhoME9MvQBI4UAANjXkfatxkta7pxbGSoqPSrp/H3OuVzS0865tZLknNvShbkBHKGvnzxApTkp+n//WqCG5lav4wDAXp3ZfewWSddKmi/pC5JekHRvOEMhNowuzdKzczaorc3J52O3BQAAQo60b9VL0roOjyslTdjnnIGSgmZWISld0u3OuYf3fSMzu17S9ZJUWFioioqKvcdqamo+8hjdi/b3Vjjb/9N923TbzAZ9/d7/6rJjEsNyjWjH739v0f7e8+IzOGRRyDnXJume0A3otNGl2Xrk/bVasbVGAwrTvY4DAEBEOIq+1f6+Ydl32llA0lhJJ0tKljTNzN5zzi3dJ8Pdku6WpPLycjdlypS9xyoqKtTxMboX7e+tcLb/FEmbAgv09/fX6JrTyzWxb25YrhPN+P3vLdrfe158BgecPmZmj4d+nW9m8/a9dV9ERKvRpVmSpA/Ymh4AgK7oW1VKKunwuFjShv2c85JzrtY5t03SW5JGdkV+AEfvu2cNVmlOir79xFzVNLZ4HQcADjpS6OuhX8/pjiCIPX1yU5WZHNQH63boknElh34BAACx7Wj7VjMkDTCzPpLWS7pU7WsIdfSMpD+HFq9OUPv0st8f4fUAdLGUhIB+e/FIXXzXNP38Px/qlxeO8DoSgDh3wJFCzrmNHc7Z7Jxb45xbI2mL9j98GfgIn880qiSLkUIAAOjo+1bOuRZJX5H0sqRFkh53zi00sxvM7IbQOYskvSRpnqTpku51zi3o+p8GwJEqL8vR9Sf01T+nr9Mbi1kLHoC3OrP72BOS2jo8bg09BxzS6NIsLdm8m+GxAAD8zxH3rZxzLzjnBjrn+jnnfh567k7n3J0dzrnNOTfEOTfMOfeHrgwOoGt889SBGlSYrpufmqfquiav4wCIY50pCgVC255KkkL3E8IXCbFkTGm2nJPmsTU9AAB70LcC4lxiwK/fXjJS22ubdMtT89Xatu+a8QDQPTpTFNpqZufteWBm50vaFr5IiCUjS7JkJk1fvd3rKAAARAr6VgA0rFembj5jsF5auEnfenyOWlrbDv0iAOhih9ySXtINkh4xsz+rfb77OklXhTUVYkZmclAji7P05tKtuvGUgV7HAQAgEtC3AiBJuu6EvmpqbdNtLy9RS5vT7z89SkF/Z763B4CucciikHNuhaSJZpYmyZxzu8MfC7HkxIH5+uPry7SjtknZqYyOBwDEN/pWADr68kn9FfCZfvniYrW2Od1+6WglBCgMAegenRkpJDM7W9JQSUlm7ZtjOOd+EsZciCFTBuXr9teW6a1lW3X+qF5exwEAwHP0rQB09IUT+yng9+mnz3+oln/M1p8vH63EgN/rWADiwCFL0GZ2p6RPS/qq2oc4Xyypd5hzIYaMKM5SdkpQby7Z6nUUAAA8R98KwP5ce1wf/eT8oXr1w8269O73tHDDTq8jAYgDnRmXONk5d5WkHc65H0uaJKkkvLEQS/w+0wkD8/Xm0q1qY2cFAADoWwHYr6smlemPl43W2qo6nfund/SjZxdqZ32z17EAxLDOFIXqQ7/WmVlPSc2S+oQvEmLRlEH5qqpt0gK+8QAAgL4VgAM6b2RPvf6tKbpiYm89PG21Tv7tm3p6dqWc48tVAF2vM0Wh580sS9JtkmZLWi3p0TBmQgw6YUC+zKQKppABAEDfCsBBZaYE9ZPzh+nZrxyn4uxkffPxubrlqfkUhgB0uUMWhZxzP3XOVTvnnlL7fPfBzrkfhD8aYkluWqJG9MpUxZItXkcBAMBT9K0AdNawXpl6+ouT9aUp/fTYzHX6xQuLKAwB6FIH3H3MzC48yDE5554OTyTEqhMHFejPry9TdV2TslLYmh4AEF/oWwE4Ej6f6TunD1JNY4vueXuVslIS9OWT+nsdC0CMONiW9Oce5JiTRMcFh+XEgfn642vL9NaybTpvZE+v4wAA0N3oWwE4ImamH507VDvrm3Xby0uUmRzUFRPZtBDA0TtgUcg5d013BkHsG1WSpayUoCqWbKEoBACIO/StABwNn8/0m4tHandDi37wzAJlJAfpUwM4agcbKSRJMrNv7ufpnZJmOefmdHkixCy/z3T8gHy9Fdqa3uczryMBANDt6FsBOFJBv093fGaMrrp/ur752BztbmjW5eNLZUa/GsCR6czuY+WSbpDUK3S7XtIUSfeY2U3hi4ZYNGVgvrbVNOnDjbu8jgIAgFfoWwE4YklBv+69ulyT+uXq//1rgb72aHtxCACORGeKQrmSxjjnvuWc+5baOzL5kk6Q9NkwZkMMOmFgviSxCxkAIJ7RtwJwVDKSgnromvH6zumD9J95G3Ten9/Vwg07vY4FIAp1pihUKqmpw+NmSb2dc/WSGsOSCjErPz1Rw3tlqmLJVq+jAADgFfpWAI6az2f68kn99c/rJqquqUWfvGOqHnl/jdexAESZzhSF/iHpPTP7oZn9UNK7kv5pZqmSPgxrOsSkKYPyNXvtDu2sY5grACAu0bcC0GUm9M3VC187XhP7tk8ne3MpX74C6LxDFoWccz+VdJ2karUvgniDc+4nzrla59xnwpwPMegTgwvU5qTn5m3wOgoAAN2OvhWArpablqh7rhqrvnmp+v6/56u+qdXrSACiRGdGCsk5N8s5d7tz7g/OuZnhDoXYNqokS8N7Zer+d1eprc15HQcAgG5H3wpAV0sM+PXzTw7Xuu31+tPry7yOAyBKdKooBHQlM9Pnj++jlVtrVbGUBacBAACArjCpX64uGlusu99aqSWbdnsdB0AUoCgET5w1vEg9MpJ079urvI4CAAAAxIzvnXWM0pMC+t6/5jMqH8AhURSCJ4J+nz57bJmmrqhi+0wAAACgi+SkJuj7Zw/RrDU79OiMdV7HARDhKArBM5eNK1VKgl/3vcNoIQAAAKCrXDimlyb1zdWtLy7Slt0NXscBEMEoCsEzmSlBXVJeoufmbtDmXfxjBQAAAHQFM9PPPzlMDc1t+t7T89XQzG5kAPaPohA89blj+6ilzemhqau9jgIAAADEjL75abr5zMH676ItOv/P77LwNID9oigET5Xmpuj0IT30yPtrVdfU4nUcAAAAIGZce1wfPXjNOFXVNuq8P7+jv01bLedYfBrA/1AUguc+f3wf7axv1lOzKr2OAgAAAMSUKYMK9OLXT9DEvrn6wTMLdd3Ds7S9tsnrWAAiBEUheG5s72yNLMnSfe+sYttMAAAAoIvlpyfqgc+O0w/OGaK3lm7Vmbe/pfdWVnkdC0AEoCgEz5mZrp7UW6ur6vTBumqv4wAAAAAxx+czXXtcH/3ry5OVmhDQ5fe8pz/8d6la+VIWiGsUhRARTj6mUAGf6ZWFm7yOAgAAAMSsoT0z9dxXj9MFo3vpD/9dpsvveU+bdrITMBCvwlYUMrMSM3vDzBaZ2UIz+3q4roXol5kc1KR+uXp54SYWvwMAAADCKDUxoN9dMkq/vXik5q/fqTNvf0uz1uzwOhYAD4RzpFCLpG85546RNFHSl81sSBivhyh3+tAeWl1Vp6Wba7yOAgAAAMS8T40t1vNfPU7pSUHd+NgHqm1kN2Ag3oStKOSc2+icmx26v1vSIkm9wnU9RL/ThhTKTHqZKWQAAABAt+ibn6bfXjJSlTvqddvLS7yOA6CbdcuaQmZWJmm0pPe743qITgUZSRpdkkVRCAAAAOhG48pydPWkMj04dbWmr9rudRwA3SgQ7guYWZqkpyTd6JzbtZ/j10u6XpIKCwtVUVEhSaqpqdl7H93Pq/bvn9ykx5c068kXX1decnyvg86fAW/R/t6i/b1F+wNA/LnpjEF6bfFm3fTkXL349ROUnOD3OhKAbhDWopCZBdVeEHrEOff0/s5xzt0t6W5JKi8vd1OmTJEkVVRUaM99dD+v2r9sWK0eX1KhXel9dNFxfbr9+pGEPwPeov29Rft7i/YHgPiTkhDQry4cocvvfV+/fWWJvn8Oy8EC8SCcu4+ZpPskLXLO/S5c10FsKctL1aDCdKaQAQAAAN1scv88XT6hVPe9u0qz17IbGRAPwjk/51hJV0r6hJnNCd3OCuP1ECNOH1qoGau3q6qm0esoAAAAQFz57pmDVZSRpO88MVcNza1exwEQZuHcfewd55w550Y450aFbi+E63qIHacN7aE2J722aIvXUQAAAIC4kp4U1C8/NUIrttbqsw9M1+6GZq8jAQij+F7JFxFpaM8M9cpKZgoZAAAA4IETB+br958eqZmrd+jSu9/T1t2M4AdiFUUhRBwz0+lDe+jt5dtU09jidRwAAAAg7nxydLHuubpcK7fW6qI7p2ptVZ3XkQCEAUUhRKTThxaqqaVNby7Z6nUUAAAAIC6dNKhAj1w3QTvrm3XhX6dq4YadXkcC0MUoCiEilZflKDc1gSlkAAAAgIfGlGbryRsmKeg3XXr3e1q3nRFDQCyhKISI5PeZThtaqP8u2szidgAAAICH+hek6/EvTJJz0s1PzZNzzutIALoIRSFErE+PK1VdU6uembPB6ygAAABAXCvJSdH3zjpGU1dU6R/T13odB0AXoSiEiDWyOFNDe2bokffX8m0EAAAA4LHLxpfo2P65+sV/FqlyB9PIgFhAUQgRy8x0+YRSLdq4S3PWVXsdBwAAAIhrZqZbLxwhJ+m7T8/ni1sgBlAUQkQ7f1QvpSb49cj7DFEFAMDMzjCzJWa23MxuOch548ys1cwu6s58AGJfSU6KbjlzsN5etk2Pz1zndRwAR4miECJaWmJA54/upefmbtDOOhacBgDELzPzS/qLpDMlDZF0mZkNOcB5v5L0cvcmBBAvrpjQWxP65Ohnzy/Sxp31XscBcBQoCiHiXT6+VI0tbXr6g0qvowAA4KXxkpY751Y655okPSrp/P2c91VJT0na0p3hAMQPn8/064tGqLmtTTc9OU9NLW1eRwK6VVub033vrNIFf3lXX/3nB/rTa8v00oJNWrWtVq1t0TWtMuB1AOBQhvXK1MiSLD3y/lp9dnKZzMzrSAAAeKGXpI5zNSolTeh4gpn1kvRJSZ+QNO5Ab2Rm10u6XpIKCwtVUVGx91hNTc1HHqN70f7eov0Pz2UDA3pg4TZdfPsr+vKoRCX4j66fTvt7i/bvnOrGNt07v0kLtrWqNN2ndVt36rm5/ysEpSdIE4sCOq5XQKXpvsP6/6sXnwFFIUSFz0wo1U1PztP0Vds1oW+u13EAAPDC/nqV+34d+QdJNzvnWg/WCXXO3S3pbkkqLy93U6ZM2XusoqJCHR+je9H+3qL9D88USf3eW6Pv/3uBHl6VoruvGquUhCP/Lybt7y3a/9DeWLxFP31irmoanX52wTB9ZkKpzEw1jS1avqVGSzftVsXSLfrvh1v06poGDe6Rrk+NKdbIkiwF/KaAzxTw+ZQQ8KlPXqr8vo/+W+3FZ0BRCFHh3BE99dPnP9Q/pq+lKAQAiFeVkko6PC6WtGGfc8olPRoqCOVJOsvMWpxz/+6WhADizhUTeysp6NdNT87VZ++fofuvGae0RP6biehV19Si+ZU7tauhRc2tbaGb05x1O/T399ZqcI90PXr9RA0oTN/7mrTEgEaVZGlUSZYuGVei6romPTdvo56aVamfv7Bov9cZWJim75w+WKccU+DpbBj+tCIqJCf49akxxfrH+2v1f+c0Kjct0etIAAB0txmSBphZH0nrJV0q6fKOJzjn+uy5b2YPSnqeghCAcLtobLESAz7d+NgcXXHv+3romvHKTAl6HQvolJ11zZq2skozV2/XjNXbtWDDrgOuC3TNsWW6+YzBSgr6D/qeWSkJunJib105sbdWbavV+h31amlrU0urU0ub0466Jt3z1kpd9/BMje2drZvPGKzxfXLC8eMdEkUhRI3LJ5Tqwamr9eSsSn3hxH5exwEAoFs551rM7Ctq31XML+l+59xCM7shdPxOTwMCiGvnjuypxIBPX/nHB7rgjnf1u0tGanRpttexgANqaG7Vfe+s0h1vLFdtU6sSAj6NKsnSF0/sp7G9s5WXlqhgwBT0+5Tg9yk1MaCc1ITDvk6fvFT1yUv92PMXjy3WE7Mq9Yf/LtUld03TJwYX6NS87l+0naIQosbAwnSNKM7UfxdtpigEAIhLzrkXJL2wz3P7LQY55z7bHZkAYI/ThvbQ364dr288NkcX3TlNXzmpv77yif4K+tn0GpHDOafn523UrS8u1vrqep02pFDXn9BXw4szlRg4+AigrhTw+3TZ+FJdMKqXHpy6Wne9tUIn5nTf9ffm6PYrAkdhXFmO/v7eGjW1tCkhwD8uAAAAQCSZ0DdXL954gn787ELd/toyvbFki37/6VHql5+mhuZWVe6o0+ptddpe26QzhvdQRhLTzBAeW3c36q2lW9XS1qbWNqnNObW2OT03d4NmrtmhY4oydNvFIzS5X56nOZMT/PrilH767OQyvT/17W6/PkUhRJUxpdm6751VWrRxl0aWZHkdBwAAAMA+MpOD+t2nR+mUIYX63r/m66zb31ZeWqI27KyX67BUyx0Vy/XXK8bqmKIM78Ii5jS3tunhaWv0h1eXandjy8eO56Ul6tYLh+vi8pKP7f7lpeSE7h8lJFEUQpQZ0ztLkjRrzQ6KQgAAAEAEO2t4kcp7Z+u3ryxVc2ubeuemqnduinrnpqimsUXffmKuPnnHu/rZBcN10dhir+MiBkxdsU0/enahlm6u0YkD8/Wd0wcpJzVBPjP5TPL5TBlJQWaddEBRCFGlKDNZPTOTNHvtDn1OfQ79AgAAAACeKchI0q8uGrHfY89/9Xh97Z8f6NtPzNWsNTt0Uub+d3wCDqVyR51++eJi/WfeRpXkJOueq8o93+o9WlAUQtQZ3TtbH6yt9joGAAAAgKOQn56ov107Xr99dan+WrFC76b7ZEWb9YnBBRE1rQeRa3dDs+6oWKH73lklk/SNUwbqCyf2PeSW8fgfikKIOmNLs/WfeRu1aWeDemQmeR0HAAAAwBEK+H26+YzBGl2SpVuemK3rHp6p3rkp+uzkMl1cXqK0RP7Lio9raW3TozPW6fevLlVVbZMuHN1L3z59kHpmJXsdLerwJwxRZ0zvbEnS7LU7dNbwIo/TAAAAADhapw3tId/mZDXkDdL976zSj5/7UL97Zakum1CqL57YT9mpCV5HhMcaW1o1c/UOvbV0q15euEmrq+o0oU+OHjx7iIYXZ3odL2pRFELUGVKUocSAT7PXUBQCAAAAYkXAZzpnRE+dM6KnPli7Q/e/u1r3vr1S/5y+Vl85qb+unlz2sWlBrW1OH27YpfXVdaqqbdL2miZV1TapsaVVnzu2jwYUpnv00+BIbN3dqA837lJtY4tqGltU09D+65x11Zq2okr1za0K+k3lvXN0y5nH6PShhawbdJQoCiHqJAR8GlGcqVlrd3gdBQAAAEAYjC7N1p9Ks/Xlk/rpVy8u1i9fXKyHp63Rt04bqOG9MvXu8m16d0WV3ltZpd0NH912PC0xoNY2p+fnbtSfLh+tKYMKPPop0FlLNu3WPW+v1LNzNqipte1jx8tyU3RJebFOGJiviX1zlcq0wi5DSyIqjSnN1gPvrlZjS6sSAywiBgAAAMSiwT0y9MA14zV1+Tb94sVF+ubjc/ceK8lJ1tnDizSpX6765acpNy1B2SkJSgr6taG6Xtc+NFOfe3CGfnDOEH12chkjSrrR8i271dLmlJkcVFZygpKCvo+0f3Nrm+qbWzV3XbXueXuV3lq6VUlBny4dX6KzhxcpMyWo1ISA0hIDSk0MsIV8GFEUQlQaXZqtu95aqQXrd2lsaI0hAAAAALFpcv88Pfvl4/TKh5tUXdesyf3yVJqbcsDze2Yl68kbJunGx+box899qOVbavSj84Yq6Ke4EE7zK3fq1y8v1tvLtn3k+YSAT+mJATW1tBeDWtrc3mN5aYn69mkD9ZkJvVk7ygMUhRCVxvTOkiTNXrODohAAAAAQB3w+0xnDOr+maGpiQHddMVa3vbJEf61YoRVba/Sd0wdpTGk2o4a62PItNfrdq0v0wvxNyk4J6pYzB6s0J0XVdc3aWd+s6vom7W5oUWLAp+Sgv/2W4FdhRpJOHVLIFvIeoiiEqFSQnqSSnGTNZl0hAAAAAAfg85luPmOw+uen6UfPLtSn/jpNg3uk6zMTe+uCUT2VnhT0OmLUWl9dr6nLt+nNpVv1wvyNSg769bWTB+i64/vQrlGEohCi1pjSbE1bUSXnHJV+AAAAAAf0qbHFOmNYDz07d4P+/t4a/eDfC/TLFxbp4rHFuvGUgUxb6oSW1jZVLNmq1xZv0bQV27S6qk6SlJOaoM9O7qMvndRPeWmJHqfE4aIohKg1pjRbz8zZoPXV9SrOPvB8YgAAAABITQzosvGlunRcieZW7tTf31ujv7+/Vs/N26hbzhysi8cWx8yXzRt31uuDtdWas65a8yqrVZiRpFOOKdSJg/KVcZijeJZvqdETs9bp6dnrtXV3o9ITA5rQN0dXTirTsf1zNbAgXT5fbLRbPKIohKi1Zy2h2WurKQoBAAAA6BQz06iSLI0qydK1x/XR9/+9QDc9OU9PzFynn10wXIN6pHsd8WM27WzQW0u3qjgnWcf0yPjIyCbnnJZvqdF7K6v03srtmrlmuzbvapQkJfh9GlyUrreXbdMzczYo4DNN6JujTwwuVN/8VOWmJignNUG5qYlqc04bd9ZrTVWd1lTVak1Vnd5ftV2z1uyQ32c6aVCBLikv1kmDC1iwO4ZQFELUGtwjXclBv2av2aHzRvb0Og4AAACAKHNMUYae+MIkPTmrUr98cZHO/uPb+tSYYp0zskgT++Z6XvxYva1Wd721Qk/NWq+m1ra9zxdmJGpQjwylBP2asXq7qmqbJEk9M5M0sW+uRpdkaVRpto4pSldiwK/WNqcP1u7Qfxdt0X8XbdZPn//wY9fymdT28ut7Hwd8pv4FafrumYP1yTG9VJCeFP4fGN2OohCiVsDv04jiTBabBgAAAHDEfD7TJeNKdMqQQv3mlSX69wfr9djMdcpKCeqUYwp15rAeOrZ/XrfskNXa5rS7oVlrqup03zur9Py8DQr4fbpkXLEuH99bVbWNWrxxtxZt2qXFG3drd2OzThyYr4l9czWxb65KcpL3OwXO7zOVl+WovCxHt5w5WBuq67VpV4Oqapq0vbZRVbVN+nDpSk0cMUi9c1PUOydVPbOSFGBEUMyjKISoNrZ3tu5+a6Xqm1qVnMA2hgAAAACOTE5qgn7xyeH6v3OG6M2lW/XSgk16eeEmPTmrUklBnyb1zdWJA/N14qACleWmHPX6Q845vbN8m+5/Z5VWbqtVdV2zdjU0y7n246kJfl13fF9de1wfFWT8b5TO8QPyj+q6ktQzK1k9s5I/8lyFKjVlYu+jfm9EF4pCiGpjSrPV0uY0r7JaE/rmeh0HAAAAQJRLCvp1+tAeOn1oDzW1tOndFdv05pKtenPpVr3x3IfScx+qNCdFxw3I0/H98zSpX66yUjq/e1lrm9NLCzbpr28u14L1u1SYkagJfXKVnRJUZkqCspKDyklN0JRB+Yf1vsCRoCiEqDYmtNj0tJVVFIUAAAAAdKmEgE8nDSrQSYMKJElrqmr11tL2AtGzczboH++vlZk0olemJvbL1eAe6eqfn65+BalKSWj/73ZLa5vWbq/T0s01Wrp5t56eXanVVXXqm5eqX31quC4Y3UuJAWY9wBsUhRDVclITNKlvrp6aXamvfWIAWyECAAAACJveuam6clKqrpxUpubWNs2rrNbby7bp3eXbdN/bq9TS5vae2zMzSelJQa3aVvuRRaJHlmTpr2cM1mlDe8jP/1/gMYpCiHqXji/R1x+do6krqnTcgDyv4wAAAACIA0G/T2N752hs7xzdeMpANbW0ae32Wi3fUrP3truhRVMG5WtAYboGFKSpf0GaUhP5bzgiB78bEfVOH9pDWSlBPTpjLUUhAAAAAJ5ICPjUvyBd/QvSvY4CdBr7yyHqJQX9+uToXnpl4WZtr23yOg4AAAAAAFGBohBiwqXjStXU2qanZ1d6HQUAAAAAgKhAUQgxYVCPdI0uzdKjM9bJOXfoFwAAAAAAEOcoCiFmXDquRMu31Gj22h1eRwEAAAAAIOJRFELMOGdET6Um+PXo9HVeRwEAAAAAIOJRFELMSE0M6LxRPfX8vI3a3dDsdRwAAAAAACIaRSHElEvHlaq+uVXPzt3gdRQAAAAAACIaRSHElBHFmRrcI50pZAAAAAAAHAJFIcQUM9Ol40o0f/1Ofbhhl9dxAAAAAACIWBSFEHPOGdlTkvT64s0eJwEAAAAAIHJRFELMyUtL1NCeGXpr6TavowAAAAAAELEoCiEmnTAwX7PX7mAXMgAAAAAADoCiEGLS8QPy1NLm9N7K7V5HAQAAAAAgIlEUQkwa2ztbKQl+vbV0q9dRAAAAAACISBSFEJMSA35N7Jurt5dRFAIAAAAAYH8oCiFmHT8gT6ur6rS2qs7rKAAAAAAARByKQohZJwzMlyS9xWghAAAAAAA+hqIQYlbfvFT1ykpmChkAAAAAAPtBUQgxy8x0wsA8TV1epebWNq/jAAAAAAAQUcJWFDKz+81si5ktCNc1gEM5fkC+dje2aO66aq+jAAAAAAAQUcI5UuhBSWeE8f2BQzq2X558Jr21bJvXUQAAAAAAiChhKwo5596StD1c7w90RmZKUCNLsvTWUtYVAgAAAACgI9YUQsw7fkC+5lVWq7quyesoAAAAAABEjIDXAczseknXS1JhYaEqKiokSTU1NXvvo/vFUvun17SqzUn3PPuWxvXw/Ld8p8XSZxCNaH9v0f7eov0jl5mdIel2SX5J9zrnbt3n+Gck3Rx6WCPpi865ud2bEgAARAvP/4fsnLtb0t2SVF5e7qZMmSJJqqio0J776H6x1P7Htbbpj3NeVVWwQFOmjPA6TqfF0mcQjWh/b9H+3qL9I5OZ+SX9RdKpkiolzTCzZ51zH3Y4bZWkE51zO8zsTLX3sSZ0f1oAABANmD6GmBfw+zS5f67eXrZNzjmv4wAAcKTGS1runFvpnGuS9Kik8zue4Jyb6pzbEXr4nqTibs4IAACiSDi3pP+npGmSBplZpZldG65rAYdy0qACra+u1+y1Ow59MgAAkamXpHUdHleGnjuQayW9GNZEAAAgqoVt+phz7rJwvTdwuM4d2VO/eGGR7ntnlcb2zvE6DgAAR8L289x+h8Ca2UlqLwodd4Dj+13TUWJNKa/R/t6i/b1F+3uL9veeF5+B52sKAd0hNTGgyyaU6p63Vmrd9jqV5KR4HQkAgMNVKamkw+NiSRv2PcnMRki6V9KZzrmq/b3RgdZ0lFhTymu0v7dof2/R/t6i/b3nxWfAmkKIG1dPKpOZ6aGpq72OAgDAkZghaYCZ9TGzBEmXSnq24wlmVirpaUlXOueWepARAABEEYpCiBs9s5J11vAiPTZjnWoaW7yOAwDAYXHOtUj6iqSXJS2S9LhzbqGZ3WBmN4RO+z9JuZLuMLM5ZjbTo7gAACAKUBRCXLn2uD7a3diix2esO/TJAABEGOfcC865gc65fs65n4eeu9M5d2fo/uedc9nOuVGhW7m3iQEAQCSjKIS4MqokS2N7Z+uBqavU2sb29AAAAACA+EVRCHHn2uP6aN32er364SavowAAAAAA4BmKQog7pw0pVK+sZN33ziqvowAAAAAA4BmKQog7Ab9P1xxbphmrd2juumqv4wAAAAAA4AmKQohLnx5XorTEgO5ltBAAAAAAIE5RFEJcSk8K6jMTSvX8vA2auXq713EAAAAAAOh2FIUQt7528gD1zEzWzU/NU0Nzq9dxAAAAAADoVhSFELdSEwP6xYXDtWJrrf7yxnKv4wAAAAAA0K0oCiGunTgwXxeO6aW/VqzQoo27vI4DAAAAAEC3oSiEuPeDs4coMzmom5+ap5bWNq/jAAAAAADQLSgKIe5lpyboR+cN1bzKnXrg3dVexwEAAAAAoFtQFAIknTOiSKccU6jfvrpEa6pqvY4DAAAAAEDYURQCJJmZfnbBMAV9Pn390TnsRgYAAAAAiHkUhYCQHplJuu3iEZpbWa1vPDZHbW3O60gAAAAAAIQNRSGggzOGFen/nXWMXlywSb94YZHXcQAAAAAACJuA1wGASHPtcX1UuaNe976zSiU5Kbp6cpnXkQAAAAAA6HIUhYB9mJl+cM4QVe6o14+fW6heWck6ZUih17EAAAAAAOhSTB8D9sPvM/3xslEa1itTX/3nB3p/ZZXXkQAAAAAA6FIUhYADSEkI6L6rx6lHZpIuv/d9/eWN5Wpl8WkAAAAAQIygKAQcRH56op79yrE6a3iRbnt5ia66/31t2dXgdSwAAAAAAI4aRSHgENKTgvrjpaP0q08N16w1O3Tm7W+rYskWr2MBAAAAAHBUKAoBnWBm+vS4Uj33leOUl5aozz4wQ3e+uULOMZ0MAAAAABCdKAoBh2FAYbqe+cqxOmdEkW59cbF++vwitbHOEAAAAAAgCrElPXCYkoJ+/fHS0cpPT9T9767Slt0N+u0lI5UY8HsdDQAAAACATqMoBBwBn8/0f+cMUY+MJP3yxcXaXtuku64cq/SkoNfRAAAAAADoFKaPAUfIzPSFE/vpd5eM1PRV23XxndM0a812r2MBAAAAANApFIWAo3ThmGLd99lx2lbTpE/9dZquf3imlm+p8ToWAAAAAAAHRVEI6AInDszXm9+Zom+dOlBTV1TptN+/qe8+PU+bdzV4HQ0AAAAAgP2iKAR0kdTEgL568gC9+Z0punpymZ6cVakpt1Xod68uVW1ji9fxAAAAAAD4CIpCQBfLTUvUD88dqte/NUWnDCnUH19bpim/qdCj09eqle3rAQAAAAARgqIQECYlOSn602Wj9a8vTVZpTopueXq+zrr9bb20YKNaWtu8jgcAAAAAiHMUhYAwG12arSdvmKS/fmaMGlpadcPfZ2vyra/rt68sUeWOOq/jAQAAAADiVMDrAEA8MDOdObxIpw4p1BtLtuof76/Rn99Yrj+/sVwnDszXRWOLdfLgQiUn+L2OCgAAAACIExSFgG4U8Pt06pBCnTqkUOur6/XYjHV6fMY6feUfHyg1wa9ThxTqvFE9dfyA/E6/p3NOSzbv1ovzN+nlhZtU19Sqfvmp6pefpn4FaeqXn6YRxZlKClJwAgAAAAD8D0UhwCO9spL1zVMH6usnD9D7q6r03NwNemH+Jv17zgalJwWUGWhV4aKpSksMKC0poLSEgFITA0pN9Cslof3XDdUNemnBRq2uqpOZNK4sR/0L0rRia62mrqhSY0v72kXpiQGdMayHLhjdSxP75srvM49/egAAAACA1ygKAR7z+0yT++Vpcr88/fi8YXp72Vb9d9EWLV2zXslBv6rrm1W5o041jS2qa2xVbVOL9mxiFvCZJvXL1fUn9NOpQwqVn564933b2pzWV9dryabdemnhJr24YJOemFWpwoxEnTuip84eUaRRJVkyo0AEAAAAAPGIohAQQRICPp18TKFOPqZQFRVVmjJlwsfOcc6poblNtU0tSgz4lJ4U3O97+XymkpwUleSk6JQhhfrZBcP02qIt+vec9Xpo2mrd+84q9cxM0unDeujMYUUa2zubEUQAAAAAEEcoCgFRxsyUnOA/7EWpk4J+nT2iSGePKNLO+ma9tmizXpi/SY+8v1YPvLta2SlB9clLVa/sFBVnJ6s4O1k5KQlqam1TU0ubmlrb1NjcpqLMJB07IE8ZByhGAQAAAACiA0UhIA5lJgd14ZhiXTimWDWNLXp98Ra9u2yb1u2o09x11Xpx/ka17Jmjth8Bn2ls72ydNLhAUwblqygzWXJSm3NykvxmykyhaAQAAAAAkYyiEBDn0hIDOm9kT503sufe51rbnLbsbtCO2mYlBHxKDPiUEPAp6PdpxdYaVSzZojcWb9WtLy7WrS8u3u/7DinK0IVjeum8kT1VkJHUXT8OAAAAAKCTKAoB+Bi/z1SUmdw+AmgfOak5GleWo++cPlibdjbo7WVbtbO+WT4zmUk+M9U2tejlhZv1s/8s0i9eWKRj++fp7OFF6l+Qpp5ZySpIT1TA7/PgJwMAAAAA7EFRCMAR65GZpIvLS/Z77EtT+mvl1hr9+4P1+tec9brl6fl7j/lM6pGRpJy0BJlM7ZPO2vXOSdVFY4t1wsB8Fr4GAAAAgDCiKAQgbPrmp+mbpw3SN04dqBVba1S5o14bdzZoQ3W91lfXa0dtk8zaCz8myUmatrJK/5m/UT0yknTR2GJdUl6i0twUT38OIJI557R5V6Na2toU9PsU8JkCfp+Sgj4lBg5vQXoAAADEF4pCAMLOzNS/IF39C9IPeW5TS5teW7RZj81cpzsqluvPbyzXwMI0DeuVqRG9MjW8OEtDijIOe/c1INq0tjk1t7bJZ6ag3/YWUCVp084Gvbt8m6auqNLUFdu0cWfDft+jR0aS+uSlqiwvVX3zUpWfnqimljY1trSqsaVNjS1tykgOakhRugb1yFBaIt0CAACAeELvD0BESQj4dObwIp05vEgbd9brXx+s18zVO/TW0m16evZ6Se27n50wMF8XjS3WyccUMBoCEc05p8aWNiUGfB8p7EhSY0urZq3ZoXeWbdM7y7dp5dZaNbW2qaW1TR03ADSTEgPtI38CPlNVbZMkKTslqEn9cvWFshylJATU3Namltb2YlJtY6vWbK/V6m21emnBRu2oaz5k1t65KTqmR4b6BVs0pSsbAQAAABGJohCAiFWUmawvTekv6X9TZOZVVmvmmh16ds4GfWnxbGUmB3XuyCKdP6qX+ualKjslQT7WIoIHNu9q0PRV2zVz9Xatr67X1pomVdU0altNoxqa2xT0m3JSE5STmqjc1AQ5Oc1as0MNzW0K+EyjS7N0cXmxEgN+Bf2mgM+ngL/993Jj8/9G9jS2tKlffqom98vT4B7pnf79Xl3XpO21TUoM+pXg9ykx6FOC36dtNY1atHG3Fm/cpUWbdmnRxt1KzW4LZ1MBAAAgQlAUAhAVzEw9MpPUI7OHThvaQzefMVjvLt+mp2ZX6omZlfr7e2sltY8iKkhPVEFGkgrSE5Wblqi8tATlpiYoLz1Rzklbdjdqy+4GbdnVqK27G5WZEtQxPdqnzwzuka5eWR/fdQ3RqbXNyaTDKhQ657RhZ4Mqt9ep1Tk5J7WFfm1pa1N9U5samltV39yqhuZWLd28W9NXbdfqqjpJUmqCXyU5KcpPT1TfvFTlpSUoKyVBuxtatL22Udtrm1RV26Tm1jZdOq5Uxw/I04S+uWGfupWV0p5jX8XZKSrOTtGpQwr3PvfGG2+ENQsAAAAiA0UhAFHJH5pCdsLAfO1qaNbU5VXavKshdGsv+qypqtPstdXaXtv4kak4kpTg96kgI1H56Ylau71O/5m3ce+x1AS/0oNtKl0yTfmholJ+eqJ6ZSerV1aKirOTVZiRJL/P5JxTfXOrdtY3a2d9s2obW/+3Xktz+9otJTkpGtErUwG/r5tbKT61tTlNX71dz8xZrxfmb1Jza5uG9czU8OJMjSjO1NCemfL7TDvqmrSzrlk76ppUVdOk5VtqtGTzbi3fUqOaxpZOXy8rJahxZTm6YmJvje+ToyFFGVH/We87zQ0AAACxiaIQgKiXkRTUGcN6HPB4a5tTdV2TttW0r8NSmJGozOTgR/7jW9PYoqWbd2vJpvbbghXrJCct2rRL23Y3alfDR4sEAZ8pMzmoXQ3Nam7dp+K0H6kJfo3rk6NJfXM1qV+uBhamKykYH2shNTS3anVVrVZurVVza5v65aepT16qUo9iZMyuhmZtrG5QXVPL3hE79U1tmre+Ws/N2aANOxuUkuDXaUMKlZWSoHmV1fr7e2vU2HLgaVG5qQkaUJimC8f00oDCdJXlpijo9+0daeQzye/zKTnoV3LQ3767V9Cv9MQAUxbRbczsDEm3S/JLutc5d+s+xy10/CxJdZI+65yb3e1BAQBAVKAoBCDm+X2m3LT2qWQHkpYY0JjSbI0pzZYkVVRs1ZQpk/Yeb2hu1frqelXuqFfljjpV7qjXzvpmZSQFlZkcVFZK+6+piYHQgsC+vWvDLN1co2krt2naiipVLNkqqX3h4KKMJPXOTVVZXop656aqf36a+hekqSQnRf4IKjI457Smqk5zK6s1r3KnFm3cpZQEv3plJatXdrJ6ZiUrPy1R1fXN2rKrQVt2N2rzrgZt3NmglVtrtWFnvdx+6mY9M5PUryBNhRlJykgKKiM5oIykoNKTAlpc2awN769Vc2ubmlvbVNfUqrXb67R6W61WV9XuLfDta88i5DefOVinDilUSsL//plraW3T8q01Wrh+l8yk7JQEZaYElZ2SoJzQfSCSmZlf0l8knSqpUtIMM3vWOfdhh9POlDQgdJsg6a+hXwEAAD6GohAAdEJS0K9++Wnql5922K8dUJius0cUSfrfYsQrt9ZqTVV7geOVhZv37iYlte/A1jcvVWW5qcpM/l+xJCN0PzM5uPeWkRxUakJASUH/EReS6ppatHFngzZWN2jTrgZt2d2grbsbtWV3o7buatSSzbu1s75956rEgE+DizK0vbZJ76/art0NH59m5TMpLy1RRZlJGleWrT55Jeqbn6o+ealKCPi0cmuNVmyt1YotNVq+tUbLt9Rod0PLx6dsLZj/kYeFGYkqy03VKccUqiwvVcXZyUpNDOwduZOc4FdhetIBizsBv0+De2RocI+MI2onIAKMl7TcObdSkszsUUnnS+pYFDpf0sPOOSfpPTPLMrMi59zGj78dAACIdxSFAKAbFWYk6dyRPT/2/M76Zq3YWqPlm9sLJcs279byrTXaVd+sXQ3Namg+9G5QQb8pKeBXYtCv5ASfkgJ+JYUKJolBn9qcU0ura/+1zam+qVUbdzbsLfh0lJYYUH56ovLTEnXW8B4aUZylEcWZGliYrmCH9XJ2NTRr/Y56batpVHZKwt7FvQ9WoBpYmL7f51ta21TT2KLdDS167733dMJxkxX0+xT0mxJCI6+AONdL0roOjyv18VFA+zunl6QDFoWqqqr04IMP7n1cXV2t1atXH2VUHCna31u0v7dof2/R/t7z4jOgKAQAESAzOfiR6Wv7ampp0+6G5r0LWu+sb9auhhbtrG9WXWOLGprb1NDSvrZO+61t7/365lbVNLbIbyafzxT0+5QUNOWmJmpcWY56ZCapZ1aSijKT1SMjSQUZiR+ZdnUwGUlBZRR1zbSrgN+3d4esFSk+FWYkdcn7AjFkf9XWfSdnduYcmdn1kq6XpKKiIlVXV+891tra+pHH6F60v7dof2/R/t6i/b3nxWdAUQgAokBCwHfIdZEAxLxKSSUdHhdL2nAE58g5d7ekuyWpvLzc3XjjjXuPVVRUaMqUKV0SGIeP9vcW7e8t2t9btL/3wvkZfOMb39jv89G9Zy4AAED8mCFpgJn1MbMESZdKenafc56VdJW1myhpJ+sJAQCAA2GkEAAAQBRwzrWY2Vckvaz2Lenvd84tNLMbQsfvlPSC2rejX672Lemv8SovAACIfGEtCpnZGZJuV3vH5V7n3K3hvB4AAEAsc869oPbCT8fn7uxw30n6cnfnAgAA0Sls08fMzC/pL5LOlDRE0mVmNiRc1wMAAAAAAEDnhXNNofGSljvnVjrnmiQ9Kun8MF4PAAAAAAAAnRTO6WO9JK3r8LhS0oSDvaCqqkoPPvigJKm6ulqrV68OVzYcAu3vPT4Db9H+3qL9vUX7AwAAxIdwFoVsP8+5j51kdr2k6yWpqKhI1dXVkqTW1ta999H9aH/v8Rl4i/b3Fu3vLdofAAAgPoSzKFQpqaTD42JJG/Y9yTl3t6S7Jam8vNzdeOONkqSKigpNmTIljPFwMLS/9/gMvEX7e4v291Y42/8b3/hGWN4XAAAAhy+cawrNkDTAzPqYWYKkSyU9G8brAQAAAAAAoJPCNlLIOddiZl+R9LLat6S/3zm3MFzXAwAAAAAAQOeFc/qYnHMvSHohnNcAAAAAAADA4Qvn9DEAAAAAAABEKIpCAAAAAAAAcYiiEAAAAAAAQByiKAQAAAAAABCHKAoBAAAAAADEIYpCAAAAAAAAcYiiEAAAAAAAQBwy55zXGfYys62S1oQe5kna5mGceEf7e4/PwFu0v7dof2+Fs/17O+fyw/TeOAL79L8k/vx5jfb3Fu3vLdrfW7S/97q9DxZRRaGOzGymc67c6xzxivb3Hp+Bt2h/b9H+3qL94xufv7dof2/R/t6i/b1F+3vPi8+A6WMAAAAAAABxiKIQAAAAAABAHIrkotDdXgeIc7S/9/gMvEX7e4v29xbtH9/4/L1F+3uL9vcW7e8t2t973f4ZROyaQgAAAAAAAAifSB4pBAAAAAAAgDDptqKQmZWY2RtmtsjMFprZ10PP55jZq2a2LPRrdofXfNfMlpvZEjM7vcPzY81sfujYH83MuuvniFaH2/5mdqqZzQq18ywz+0SH96L9j8CR/BkIHS81sxoz+3aH5/gMDtMR/h00wsymhc6fb2ZJoedp/8N0BH8HBc3soVA7LzKz73Z4L9r/MB2k/S8OPW4zs/J9XsO/wTGCPpi36IN5i/6Xt+h/eYv+l/eiog/mnOuWm6QiSWNC99MlLZU0RNKvJd0Sev4WSb8K3R8iaa6kREl9JK2Q5A8dmy5pkiST9KKkM7vr54jW2xG0/2hJPUP3h0la3+G9aP9u+Aw6vO4pSU9I+jafQfe1v6SApHmSRoYe5/J3ULe2/+WSHg3dT5G0WlIZ7d/l7X+MpEGSKiSVdziff4Nj6HYEf/74/L1tf/pgHrZ/h9fR//Kg/UX/y+v2p//VfZ9BxPTBum2kkHNuo3Nuduj+bkmLJPWSdL6kh0KnPSTpgtD989X+G7LRObdK0nJJ482sSFKGc26aa2+Zhzu8BgdwuO3vnPvAObch9PxCSUlmlkj7H7kj+DMgM7tA0kq1fwZ7nuMzOAJH0P6nSZrnnJsbek2Vc66V9j8yR9D+TlKqmQUkJUtqkrSL9j8yB2p/59wi59yS/byEf4NjCH0wb9EH8xb9L2/R//IW/S/vRUMfzJM1hcysTO3fgrwvqdA5t1FqbzBJBaHTekla1+FllaHneoXu7/s8OqmT7d/RpyR94JxrFO3fJTrzGZhZqqSbJf14n5fzGRylTv4ZGCjJmdnLZjbbzG4KPU/7H6VOtv+TkmolbZS0VtJvnHPbRfsftX3a/0D4NzhG0QfzFn0wb9H/8hb9L2/R//JepPbBAl3xJofDzNLUPhzzRufcroNMg9vfAXeQ59EJh9H+e84fKulXaq/aS7T/UTuMz+DHkn7vnKvZ5xw+g6NwGO0fkHScpHGS6iS9ZmazJO36/+3dTagVZRzH8e+vF4gUegOLUrCFUC2i0nyB3qiIaOcikBANF9Eiqo2LXhZWVOAiWrgJsl3LsoJCI+lVeqMSUUsskIhASQoS6QX5tzgjnMRrnfF65t4z3w8M99xnZg7P/c/lzI/nPDNzkm2t//80Qv2XAseAy4GLgI+TvIf//6flxPqfatOTtHkOnuXMYN0yg3XL/NUt81e3zF/dm8kZbKwzhZKcy6AQr1bV603zwWYq1PFpmYea9p+ABUO7zwd+btrnn6Rd/2HE+pNkPrAFWFNVPzTN1v80jHgMlgEbkxwAHgUeT/IQHoPWWnwGfVhVv1TVUeAd4Aasf2sj1v8+YGtV/V1Vh4AdwBKsf2tT1H8qnoMnjBmsW2awbpm/umX+6pb5q3szPYON8+ljATYD31bVC0Or3gLWNq/XAm8Ota9qrqG+ElgEfNFMb/s9yfLmPdcM7aMpjFr/JBcCbwOPVdWO4xtb//ZGPQZVdXNVLayqhcCLwHNVtclj0E6Lz6BtwLVJzm+uq74V2Gv922lR/x+B2zMwB1gOfGf92zlF/afiOXiCmMG6ZQbrlvmrW+avbpm/ujcrMliN767bNzGY3rQL2Nks9zC4o/x2YH/z8+KhfZ5gcLftfQzdWZvBaOXuZt0mIOP6O2brMmr9gScZXE+6c2iZZ/3HdwxO2HcD/376hcdgDPUHVjO4yeRuYKP1H1/9gbkMnvqyB9gLrLf+Z6T+Kxl88/QncBDYNrSP5+AJWVp+/nn8O6o/ZrBO63/Cvhswf429/pi/Oqs/5q9xHoMZk8HSvLkkSZIkSZJ6pJOnj0mSJEmSJKlbDgpJkiRJkiT1kINCkiRJkiRJPeSgkCRJkiRJUg85KCRJkiRJktRDDgpJkiRJkiT1kINCkma8JGd33QdJkqS+MYNJk89BIUnTKskzSR4Z+v3ZJA8nWZ/kyyS7kjw1tP6NJF8l2ZPkgaH2I0meTvI5sGLMf4YkSdKsYgaT1IaDQpKm22ZgLUCSs4BVwEFgEbAUuA5YnOSWZvt1VbUYWAI8nOSSpn0OsLuqllXVJ2PsvyRJ0mxkBpM0snO67oCkyVJVB5IcTnI9cCnwDXAjcFfzGmAug4DyEYMQsrJpX9C0HwaOAa+Ns++SJEmzlRlMUhsOCkk6E14G7gcuA14B7gCer6qXhjdKchtwJ7Ciqo4m+QA4r1n9R1UdG1N/JUmSJoEZTNJIvHxM0pmwBbibwbdT25plXZK5AEmuSDIPuAD4tQkjVwHLu+qwJEnSBDCDSRqJM4UkTbuq+ivJ+8BvzTdN7ya5Gvg0CcARYDWwFXgwyS5gH/BZV32WJEma7cxgkkaVquq6D5ImTHNzw6+Be6tqf9f9kSRJ6gMzmKRRefmYpGmV5Brge2C7YUSSJGk8zGCS2nCmkCRJkiRJUg85U0iSJEmSJKmHHBSSJEmSJEnqIQeFJEmSJEmSeshBIUmSJEmSpB5yUEiSJEmSJKmHHBSSJEmSJEnqoX8AksFdW0Z6kN8AAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 1440x576 with 2 Axes>"
       ]
@@ -2168,16 +2300,14 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e5fda168",
+   "cell_type": "raw",
+   "id": "7c732a0b",
    "metadata": {},
-   "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "d5813a18",
+   "id": "36de0575",
    "metadata": {},
    "source": [
     "### Compare fixed geometry mass-balance from observational climate dataset to ISIMIP3b:"
@@ -2185,8 +2315,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
-   "id": "e69aa27a",
+   "execution_count": 48,
+   "id": "1b2618a1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-07-07 10:55:40: oggm.utils: Applying global task compile_fixed_geometry_mass_balance on 2 glaciers\n",
+      "2022-07-07 10:55:40: oggm.workflow: Execute entity tasks [fixed_geometry_mass_balance] on 2 glaciers\n",
+      "2022-07-07 10:55:40: oggm.utils: Applying global task compile_fixed_geometry_mass_balance on 2 glaciers\n",
+      "2022-07-07 10:55:40: oggm.workflow: Execute entity tasks [fixed_geometry_mass_balance] on 2 glaciers\n"
+     ]
+    }
+   ],
+   "source": [
+    "pd_fixed_geom= utils.compile_fixed_geometry_mass_balance(gdirs, climate_filename='climate_historical', climate_input_filesuffix='')\n",
+    "pd_fixed_geom_gcm= utils.compile_fixed_geometry_mass_balance(gdirs, climate_filename='gcm_data', climate_input_filesuffix=fs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "762ff006",
    "metadata": {},
    "outputs": [
     {
@@ -2207,13 +2359,8 @@
     "#opath = os.path.join(sum_dir, 'fixed_geometry_mass_balance_{}.csv'.format(rgi_reg))\n",
     "fig,axs = plt.subplots(1,2,figsize=(20,8),sharey=True)\n",
     "for j,gdir in enumerate(gdirs):\n",
-    "    pf = gdir.read_json('local_mustar')['prcp_fac_from_winter_prcp']\n",
-    "    fixed_geom = oggm.core.massbalance.fixed_geometry_mass_balance(gdir, precipitation_factor = pf)\n",
-    "    axs[j].plot(fixed_geom, label = 'GSWP3_W5E5')\n",
-    "    \n",
-    "    fixed_geom_gcm = oggm.core.massbalance.fixed_geometry_mass_balance(gdir, precipitation_factor = pf,climate_filename='gcm_data',\n",
-    "                                climate_input_filesuffix=fs)\n",
-    "    axs[j].plot(fixed_geom_gcm, label = f'GCM: {ensemble} {ssp}')\n",
+    "    axs[j].plot(pd_fixed_geom[gdir.rgi_id], label = 'GSWP3_W5E5')\n",
+    "    axs[j].plot(pd_fixed_geom_gcm[gdir.rgi_id], label = f'GCM: {ensemble} {ssp}')\n",
     "    if j == 0:\n",
     "        axs[j].legend()\n",
     "        axs[j].set_ylabel(r'specific MB (kg m$^{2}$)')\n",
@@ -2223,20 +2370,17 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92b78962",
+   "id": "712d86bc",
    "metadata": {},
    "source": [
     "TODO: \n",
-    "\n",
-    "- get pf directly inside of `run_from_climate` ... (and similarly for `run_constant_climate` and `run_random_climate` ...)\n",
-    "    - (this removes the loop)\n",
     "- add mu_star, prcp_fac to run_from_climate output files?\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b31638f0",
+   "id": "7687d0b7",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -2244,7 +2388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d554f68e",
+   "id": "01359908",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -2252,7 +2396,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43874bf5",
+   "id": "405e4274",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -2260,30 +2404,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e9ee5ffd",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9f2407aa",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6a177a60",
+   "id": "2eca8df4",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "912f8fab",
+   "id": "05a8d19d",
    "metadata": {},
    "source": [
     "## Other stuff from prepro level that is not so important for the notebook example workflow probably"
@@ -2292,7 +2420,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a51d0244",
+   "id": "a559412b",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -2300,7 +2428,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "da88640e",
+   "id": "80fadcf6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2313,7 +2441,7 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "c1566535",
+   "id": "7002a32d",
    "metadata": {},
    "outputs": [
     {
@@ -2374,7 +2502,7 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "95f68047",
+   "id": "b478054c",
    "metadata": {},
    "outputs": [
     {
@@ -2398,7 +2526,7 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "b8d43d75",
+   "id": "8e4cb610",
    "metadata": {},
    "outputs": [
     {
@@ -2421,21 +2549,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ddf55b80",
+   "id": "7838a40a",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "ba79dd93",
+   "id": "3ccc5cb9",
    "metadata": {},
    "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0174f4b2",
+   "id": "9be7a54f",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -2443,14 +2571,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ff50e188",
+   "id": "fc59597e",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "af4ce925",
+   "id": "aa8f5170",
    "metadata": {},
    "source": [
     "### OLD stuff"
@@ -2459,29 +2587,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27a13d12",
+   "id": "99ecf4a9",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "7ea02b1d",
+   "id": "0e4ca4e8",
    "metadata": {},
    "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a898ee06",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3d2a21ac",
+   "id": "c8e06b73",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -2489,7 +2609,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9573989f",
+   "id": "634b8779",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -2497,7 +2617,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c5ddd21",
+   "id": "fc7588ae",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -2505,7 +2625,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6ec0f7bb",
+   "id": "4c31f9df",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -2513,7 +2633,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6b7ba8af",
+   "id": "6603689c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e912e5aa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2717,7 +2845,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56bd717d",
+   "id": "33d17ea6",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -2725,7 +2853,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a0e6afc",
+   "id": "07f4de17",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -2733,7 +2861,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fd976c77",
+   "id": "54102d73",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -2741,7 +2869,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e5fdec9f",
+   "id": "42a331b7",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -2749,14 +2877,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "933c8a25",
+   "id": "2e3eec60",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "13a76e53",
+   "id": "d33529fb",
    "metadata": {},
    "source": [
     "## geodetic data from Hugonnet et al. (2021)"
@@ -2765,7 +2893,7 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "id": "a5508312",
+   "id": "de9e3d8f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2798,7 +2926,7 @@
   {
    "cell_type": "code",
    "execution_count": 52,
-   "id": "f16c12d5",
+   "id": "316abdce",
    "metadata": {},
    "outputs": [
     {
@@ -2819,7 +2947,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "8eda37a9",
+   "id": "430bd87a",
    "metadata": {},
    "outputs": [
     {
@@ -3154,7 +3282,7 @@
   {
    "cell_type": "code",
    "execution_count": 134,
-   "id": "f7435b96",
+   "id": "c0dda8ba",
    "metadata": {},
    "outputs": [
     {
@@ -3187,7 +3315,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c55a3bd5",
+   "id": "3f3d26bf",
    "metadata": {},
    "source": [
     "- for some few glaciers, there are no geodetic measurements!"
@@ -3195,7 +3323,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d855317",
+   "id": "fade8be1",
    "metadata": {},
    "source": [
     "## calibration: "
@@ -3203,7 +3331,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "144c771d",
+   "id": "6cdcca17",
    "metadata": {},
    "source": [
     "- have to set the hydro_year to 1 (geodetic data corresponds to MB from Jan 2000 to Jan 2020)!!!"
@@ -3212,7 +3340,7 @@
   {
    "cell_type": "code",
    "execution_count": 136,
-   "id": "67eb87ff",
+   "id": "81143115",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3224,7 +3352,7 @@
   {
    "cell_type": "code",
    "execution_count": 143,
-   "id": "5f1812e9",
+   "id": "bdc7157a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3276,7 +3404,7 @@
   {
    "cell_type": "code",
    "execution_count": 158,
-   "id": "a088f659",
+   "id": "bc620dd9",
    "metadata": {},
    "outputs": [
     {
@@ -3301,7 +3429,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2488a410",
+   "id": "dd1039fb",
    "metadata": {},
    "source": [
     "**important**: \n",
@@ -3311,7 +3439,7 @@
   {
    "cell_type": "code",
    "execution_count": 159,
-   "id": "1355c8d3",
+   "id": "c27cfcce",
    "metadata": {},
    "outputs": [
     {
@@ -3348,7 +3476,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3d43062",
+   "id": "0ac5f294",
    "metadata": {},
    "source": [
     "## check and validation\n",
@@ -3358,7 +3486,7 @@
   {
    "cell_type": "code",
    "execution_count": 160,
-   "id": "cf31afa0",
+   "id": "8ab4e1f5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3374,7 +3502,7 @@
   {
    "cell_type": "code",
    "execution_count": 161,
-   "id": "0ebd73ce",
+   "id": "20de7e36",
    "metadata": {},
    "outputs": [
     {
@@ -3440,7 +3568,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5e9e2ab8",
+   "id": "15595603",
    "metadata": {},
    "source": [
     "- if you want to use the new calibration to do projections and use e.g. `run_from_climate_data`, we need to adapt the function because the new calibrated `mu_star` has to be included\n",
@@ -3453,7 +3581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34a66396",
+   "id": "c7108b3f",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
- changed `run_from_climate_data` to allow to take prcp. fac and temp. bias from the json file by keyword agrument  `all_from_json` + allow different json names. This was necessary to look at different calibration options 

- updated the [geodetic_mb_calibration_to_volume_changes.ipynb](https://github.com/OGGM/massbalance-sandbox/compare/master...lilianschuster:dev2?expand=1#diff-d435913e0ee0936ad0db6e388a3e9cb8636e17743d6e18dce6a26f8e78c760e3) notebook to the new OGGM changes of https://github.com/OGGM/oggm/pull/1435